### PR TITLE
Fix PyInstaller packaging for mypyc modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,10 @@ $(BINARY_CACHE): $(WHEEL_CACHE) | $(CACHE_DIR)
 	@echo "datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]" >> $(PACKAGE_NAME)_$(VERSION)_$(PLATFORM_SUFFIX).spec
 	@echo "tmp_ret = collect_all('click')" >> $(PACKAGE_NAME)_$(VERSION)_$(PLATFORM_SUFFIX).spec
 	@echo "datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]" >> $(PACKAGE_NAME)_$(VERSION)_$(PLATFORM_SUFFIX).spec
+	@echo "tmp_ret = collect_all('tomli')" >> $(PACKAGE_NAME)_$(VERSION)_$(PLATFORM_SUFFIX).spec
+	@echo "datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]" >> $(PACKAGE_NAME)_$(VERSION)_$(PLATFORM_SUFFIX).spec
+	@echo "tmp_ret = collect_all('charset_normalizer')" >> $(PACKAGE_NAME)_$(VERSION)_$(PLATFORM_SUFFIX).spec
+	@echo "datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]" >> $(PACKAGE_NAME)_$(VERSION)_$(PLATFORM_SUFFIX).spec
 	@echo '' >> $(PACKAGE_NAME)_$(VERSION)_$(PLATFORM_SUFFIX).spec
 	@echo "a = Analysis(" >> $(PACKAGE_NAME)_$(VERSION)_$(PLATFORM_SUFFIX).spec
 	@echo "    ['src/mcli/app/main.py']," >> $(PACKAGE_NAME)_$(VERSION)_$(PLATFORM_SUFFIX).spec


### PR DESCRIPTION
## Summary
- include `tomli` and `charset_normalizer` in PyInstaller `collect_all` calls

## Testing
- `make test` *(fails: Parameter.make_metavar() missing 'ctx')*

------
https://chatgpt.com/codex/tasks/task_e_6849be632c2c83318121612c3e2b8b2e