### PR TITLE
Remove Typer dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,8 +160,7 @@ $(BINARY_CACHE): $(WHEEL_CACHE) | $(CACHE_DIR)
 	@echo '' >> $(PACKAGE_NAME)_$(VERSION)_$(PLATFORM_SUFFIX).spec
 	@echo "datas = [('src/mcli/private', 'mcli/private'), ('src/mcli/public', 'mcli/public'), ('db', 'db'), ('dependencies', 'dependencies')]" >> $(PACKAGE_NAME)_$(VERSION)_$(PLATFORM_SUFFIX).spec
 	@echo 'binaries = []' >> $(PACKAGE_NAME)_$(VERSION)_$(PLATFORM_SUFFIX).spec
-	@echo "hiddenimports = ['typer', 'typer.completion', 'click', 'pandas', 'numpy', 'watchdog', 'openai', 'git', 'flask', 'cachetools', 'tomli', 'ipywidgets', 'encodings', 'encodings.utf_8', 'encodings.cp1252', 'encodings.ascii', 'encodings.idna', 'encodings.latin_1', 'codecs', 'InquirerPy', 'requests']" >> $(PACKAGE_NAME)_$(VERSION)_$(PLATFORM_SUFFIX).spec
-	@echo "tmp_ret = collect_all('typer')" >> $(PACKAGE_NAME)_$(VERSION)_$(PLATFORM_SUFFIX).spec
+	@echo "hiddenimports = ['click', 'pandas', 'numpy', 'watchdog', 'openai', 'git', 'flask', 'cachetools', 'tomli', 'ipywidgets', 'encodings', 'encodings.utf_8', 'encodings.cp1252', 'encodings.ascii', 'encodings.idna', 'encodings.latin_1', 'codecs', 'InquirerPy', 'requests']" >> $(PACKAGE_NAME)_$(VERSION)_$(PLATFORM_SUFFIX).spec
 	@echo "datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]" >> $(PACKAGE_NAME)_$(VERSION)_$(PLATFORM_SUFFIX).spec
 	@echo "tmp_ret = collect_all('click')" >> $(PACKAGE_NAME)_$(VERSION)_$(PLATFORM_SUFFIX).spec
 	@echo "datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]" >> $(PACKAGE_NAME)_$(VERSION)_$(PLATFORM_SUFFIX).spec

--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ This project relies on several dependencies to provide its functionality. Key de
 
 - [requests](https://pypi.org/project/requests/): HTTP library for Python.
 - [ipython](https://pypi.org/project/ipython/): Interactive computing in Python.
-- [typer](https://pypi.org/project/typer/): Build great CLIs with Python.
 - [click](https://pypi.org/project/click/): Python package for creating command-line interfaces.
 - [cython](https://pypi.org/project/Cython/): C-Extensions for Python.
 - [tensorflow](https://pypi.org/project/tensorflow/): Machine learning library.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-  "typer>=0.12.0,<0.13.0",
   "click>=8.1.7,<9.0.0",
   "ipython>=8.12.0,<9.0.0",
   "pandoc>=2.3,<3.0",

--- a/src/mcli/app/main.py
+++ b/src/mcli/app/main.py
@@ -4,8 +4,6 @@ import inspect
 import importlib
 from pathlib import Path
 from typing import Optional, List
-import typer
-from typer import Typer, Option
 from importlib.metadata import version, metadata
 from functools import lru_cache
 import click
@@ -164,12 +162,12 @@ def discover_modules(
     return modules
 
 
-def create_app() -> Typer:
-    """Creates and configures the Typer application with dynamically loaded commands."""
+def create_app() -> click.Group:
+    """Create and configure the Click application with dynamically loaded commands."""
     
     logger.debug("create_app")
     
-    app = Typer(name="mcli", add_completion=True, no_args_is_help=True, rich_markup_mode=None)
+    app = click.Group(name="mcli")
 
     @app.command()
     def hello():
@@ -177,11 +175,8 @@ def create_app() -> Typer:
         logger.info("Hello from mcli!")
 
     @app.command()
-    def version(
-        verbose: Optional[bool] = Option(
-            False, "--verbose", "-v", help="Show additional system information"
-        ),
-    ):
+    @click.option("--verbose", "-v", is_flag=True, help="Show additional system information")
+    def version(verbose: bool):
         """Show mcli version and system information"""
         logger.info(get_version_info(verbose))
 
@@ -195,75 +190,25 @@ def create_app() -> Typer:
     # Add self commands explicitly
     try:
         if 'self_app' in globals():
-            # Create a Typer app to wrap the Click-based self_app
-            self_typer_app = Typer(name="self", help="Manage and extend the mcli application", no_args_is_help=True, rich_markup_mode=None)
-            
-            # Add each command from the Click group to the Typer app
-            for cmd_name, cmd in self_app.commands.items():
-                # Create wrapper function for each command
-                def create_click_wrapper(click_cmd):
-                    @functools.wraps(click_cmd.callback)
-                    def wrapper(*args, **kwargs):
-                        # Filter out typer context if it was passed
-                        if 'ctx' in kwargs and isinstance(kwargs['ctx'], typer.Context):
-                            del kwargs['ctx']
-                        yield click_cmd.callback(*args, **kwargs)
-                    return wrapper
-                
-                # Register the command
-                self_typer_app.command(name=cmd_name)(create_click_wrapper(cmd))
-            
-            # Add the self commands to the main app
-            app.add_typer(self_typer_app)
+            app.add_command(self_app, name="self")
             logger.info("Added self management commands to mcli")
     except Exception as e:
         logger.error(f"Error adding self management commands: {e}")
         import traceback
         logger.error(f"Traceback: {traceback.format_exc()}")
         
-    # # Import each module and register its commands properly
+    # Import each module and register its commands
     for module_name in module_names:
         try:
             module = importlib.import_module(module_name)
 
-            # Look for Click groups first
             for name, obj in inspect.getmembers(module):
                 if isinstance(obj, click.Group):
-                    # Create a Typer app for each group
-                    group_app = Typer(
-                        name=obj.name, help=obj.help, no_args_is_help=True, rich_markup_mode=None
-                    )
-
-                    def create_wrapper(callback):
-                        @functools.wraps(callback)
-                        def wrapper(*args, **kwargs):
-                            return callback(*args, **kwargs)
-
-                        try:
-                            sig = inspect.signature(callback)
-                            parameters = list(sig.parameters.values())
-                            # Remove the first parameter if it's the context (named "ctx")
-                            if parameters and parameters[0].name == "ctx":
-                                parameters = parameters[1:]
-                            new_sig = inspect.Signature(parameters)
-                            wrapper.__signature__ = new_sig
-                        except Exception as e:
-                            logger.error(f"Error preserving signature: {e}")
-                        return wrapper
-
-                    app.add_typer(group_app, name=obj.name)
-
-                    # Add each command from the Click group to the Typer app
-                    for cmd_name, cmd in obj.commands.items():
-                        logger.info(f"Adding command {cmd_name} to group {obj.name}")
-                        group_app.command(name=cmd_name)(create_wrapper(cmd.callback))
-                        logger.info(cmd_name)
-
-                elif isinstance(obj, typer.Typer):
-                    # It's already a Typer app
-                    app.add_typer(obj, name=obj.info.name)
-                else:
-                    pass
+                    logger.info(f"Adding group {obj.name}")
+                    app.add_command(obj, name=obj.name)
+                elif isinstance(obj, click.Command):
+                    logger.info(f"Adding command {obj.name}")
+                    app.add_command(obj, name=obj.name)
 
         except ImportError as e:
             logger.warning(f"Could not import module {module_name}: {e}")

--- a/uv.lock
+++ b/uv.lock
@@ -2118,7 +2118,6 @@ dependencies = [
     { name = "timeout" },
     { name = "tomli" },
     { name = "tqdm" },
-    { name = "typer" },
     { name = "watchdog" },
     { name = "xlsxwriter" },
 ]
@@ -2179,7 +2178,6 @@ requires-dist = [
     { name = "timeout", specifier = ">=0.1.2" },
     { name = "tomli", specifier = ">=2.2.1" },
     { name = "tqdm", specifier = ">=4.66.1,<5.0.0" },
-    { name = "typer", specifier = ">=0.12.0,<0.13.0" },
     { name = "watchdog", specifier = ">=3.0.0,<4.0.0" },
     { name = "xlsxwriter", specifier = ">=3.2.3" },
 ]
@@ -3816,7 +3814,6 @@ wheels = [
 ]
 
 [[package]]
-name = "typer"
 version = "0.12.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
@@ -3825,9 +3822,7 @@ dependencies = [
     { name = "shellingham" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/58/a79003b91ac2c6890fc5d90145c662fd5771c6f11447f116b63300436bc9/typer-0.12.5.tar.gz", hash = "sha256:f592f089bedcc8ec1b974125d64851029c3b1af145f04aca64d69410f0c9b722", size = 98953, upload-time = "2024-08-24T21:17:57.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/2b/886d13e742e514f704c33c4caa7df0f3b89e5a25ef8db02aa9ca3d9535d5/typer-0.12.5-py3-none-any.whl", hash = "sha256:62fe4e471711b147e3365034133904df3e235698399bc4de2b36c8579298d52b", size = 47288, upload-time = "2024-08-24T21:17:55.451Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- drop Typer usage from `main.py` and use Click directly
- remove Typer from dependency list
- update Makefile instructions
- clean README dependency table
- prune Typer from lock file

## Testing
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6855a683d6e883319eb16339a7629379