### PR TITLE
Improve CLI with Rich styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ You can find more detailed usage instructions in the [documentation](https://git
 - **Dependency Management**: Simplifies handling project dependencies using `poetry`.
 - **Packaging**: Easy-to-use tools for building and distributing Python packages.
 - **CLI Interface**: Command-line tools built with Python Click for efficient project management.
+- **Colorful Output**: Uses the Rich library to provide accessible, colorized command output.
 - **Cython Support**: Optionally compile Python code to C for improved performance.
 
 ## Dependencies

--- a/src/mcli/app/main.py
+++ b/src/mcli/app/main.py
@@ -8,6 +8,7 @@ from importlib.metadata import version, metadata
 from functools import lru_cache
 import click
 import functools
+from mcli.lib.ui.styling import info, success
 import tomli
 import os
 from mcli.lib.logger.logger import get_logger, enable_runtime_tracing, disable_runtime_tracing
@@ -172,13 +173,17 @@ def create_app() -> click.Group:
     @app.command()
     def hello():
         """Test command to verify CLI is working"""
-        logger.info("Hello from mcli!")
+        message = "Hello from mcli!"
+        logger.info(message)
+        success(message)
 
     @app.command()
     @click.option("--verbose", "-v", is_flag=True, help="Show additional system information")
     def version(verbose: bool):
         """Show mcli version and system information"""
-        logger.info(get_version_info(verbose))
+        message = get_version_info(verbose)
+        logger.info(message)
+        info(message)
 
     # Get the base path (mcli root)
     base_path = Path(__file__).parent.parent  # Updated to point to src/mcli instead of src/mcli/app

--- a/src/mcli/lib/ui/styling.py
+++ b/src/mcli/lib/ui/styling.py
@@ -1,0 +1,18 @@
+from rich.console import Console
+
+console = Console()
+
+
+def info(message: str) -> None:
+    """Display an informational message with cyan coloring."""
+    console.print(f"[bold cyan]{message}[/bold cyan]")
+
+
+def success(message: str) -> None:
+    """Display a success message in green."""
+    console.print(f"[bold green]{message}[/bold green]")
+
+
+def error(message: str) -> None:
+    """Display an error message in red."""
+    console.print(f"[bold red]{message}[/bold red]")


### PR DESCRIPTION
## Summary
- add new Rich-based styling helpers
- update CLI commands to show colorful output
- document color output in README

## Testing
- `python tests/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_685ca3eb743c833187ed623c997e5ddf