### PR TITLE
fix: Remove conflicting preexec_fn in services + bump v8.0.36

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcli-framework"
-version = "8.0.35"
+version = "8.0.36"
 description = "Portable workflow framework - transform any script into a versioned, schedulable command. Store in ~/.mcli/workflows/, version with lockfile, run as daemon or cron job."
 readme = "README.md"
  requires-python = ">=3.10"

--- a/src/mcli/lib/services/manager.py
+++ b/src/mcli/lib/services/manager.py
@@ -91,7 +91,6 @@ class ServiceManager:
                 stderr=stderr_handle,
                 cwd=config.working_dir,
                 env=env,
-                preexec_fn=os.setsid,
                 start_new_session=True,
             )
 


### PR DESCRIPTION
## Summary
- Fix `SubprocessError: Exception occurred in preexec_fn` when starting services via `mcli services start`
- `preexec_fn=os.setsid` and `start_new_session=True` both call `setsid()`, causing conflict in child process
- Bumps version to 8.0.36 for PyPI release (8.0.35 was skipped due to `skip-existing`)

## Test plan
- [x] All 53 service unit tests pass
- [x] Full CRUD lifecycle tested manually: start → list → status → info → logs → restart → stop → cleanup
- [x] HTTP health check endpoint verified with curl

## Summary by Sourcery

Fix service process startup session handling and bump the framework version for release.

Bug Fixes:
- Resolve subprocess startup failures by removing the conflicting preexec_fn when starting services.

Build:
- Bump project version to 8.0.36 for PyPI release.