### PR TITLE
chore: Bump version to 8.0.37

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcli-framework"
-version = "8.0.36"
+version = "8.0.37"
 description = "Portable workflow framework - transform any script into a versioned, schedulable command. Store in ~/.mcli/workflows/, version with lockfile, run as daemon or cron job."
 readme = "README.md"
  requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bumps version to 8.0.37 so PyPI publish picks up the services emoji fix from PR #149
- Previous merge at 8.0.36 was skipped by `skip-existing`