### PR TITLE
feat: Language suffix disambiguation for duplicate command names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,7 +360,7 @@ gh run watch <run-id>              # Watch run in real-time
 8. Push tags: `git push origin vX.Y.Z`
 9. GitHub Actions will automatically build and publish
 
-**Release Notes Template**: See [docs/releases/7.10.2.md](docs/releases/7.10.2.md) for the expected format
+**Release Notes Template**: See [docs/releases/8.0.8.md](docs/releases/8.0.8.md) for the expected format
 
 ## Entry Points
 
@@ -371,5 +371,3 @@ Defined in `pyproject.toml [project.scripts]`:
 - `mcli-backtest`: Backtesting (`mcli.ml.backtesting.run:main`)
 - `mcli-optimize`: Portfolio optimization (`mcli.ml.optimization.optimize:main`)
 - `mcli-dashboard`: Dashboard launcher (`mcli.ml.dashboard:main`)
-- For lsh, always test by running ls always match
-- For lsh, always test by running ls always match

--- a/src/mcli/lib/logger/logger.py
+++ b/src/mcli/lib/logger/logger.py
@@ -25,9 +25,9 @@ class McliLogger:
     _runtime_tracing_enabled: bool = False
     _system_tracing_enabled: bool = False
     _system_trace_interval: int = 5  # Default to check every 5 seconds
-    _system_trace_process_ids: Set[int] = set()  # Process IDs to monitor
+    _system_trace_process_ids: set[int] = set()  # Process IDs to monitor
     _system_trace_thread: Optional[threading.Thread] = None
-    _excluded_modules: Set[str] = set()
+    _excluded_modules: set[str] = set()
     _trace_level: int = 0  # 0=off, 1=function calls, 2=line by line, 3=verbose
     _system_trace_level: int = 0  # 0=off, 1=basic, 2=detailed
 
@@ -54,7 +54,7 @@ class McliLogger:
 
     @classmethod
     def enable_runtime_tracing(
-        cls, level: int = 1, excluded_modules: Optional[List[str]] = None
+        cls, level: int = 1, excluded_modules: Optional[list[str]] = None
     ) -> None:
         """
         Enable Python interpreter runtime tracing.
@@ -279,7 +279,7 @@ class McliLogger:
 
         return True
 
-    def _get_process_info(self, pid: int, detailed: bool = False) -> Dict[str, Any]:
+    def _get_process_info(self, pid: int, detailed: bool = False) -> dict[str, Any]:
         """Get information about a process given its PID."""
         try:
             # Check if process exists
@@ -339,7 +339,7 @@ class McliLogger:
         except Exception as e:
             return {"pid": pid, "status": "ERROR", "error": str(e)}
 
-    def _format_process_info(self, info: Dict[str, Any]) -> str:
+    def _format_process_info(self, info: dict[str, Any]) -> str:
         """Format process information for logging."""
         if info.get("status") == "NOT_FOUND":
             return f"Process {info['pid']} no longer exists"
@@ -475,7 +475,7 @@ class McliLogger:
                 if self._trace_level >= 3:
                     # Include source line in verbose mode
                     try:
-                        with open(filename, "r") as f:
+                        with open(filename) as f:
                             lines = f.readlines()
                             source = (
                                 lines[lineno - 1].strip()
@@ -543,7 +543,7 @@ def get_system_trace_logger() -> logging.Logger:
     return McliLogger.get_system_trace_logger()
 
 
-def enable_runtime_tracing(level: int = 1, excluded_modules: Optional[List[str]] = None) -> None:
+def enable_runtime_tracing(level: int = 1, excluded_modules: Optional[list[str]] = None) -> None:
     """
     Enable Python interpreter runtime tracing.
 

--- a/src/mcli/lib/shell/shell.py
+++ b/src/mcli/lib/shell/shell.py
@@ -39,7 +39,7 @@ logger = get_logger(__name__)
 MAX_COMMAND_LENGTH = 100000
 
 
-def shell_exec(script_path: str, function_name: str, *args) -> Optional[Dict[str, Any]]:
+def shell_exec(script_path: str, function_name: str, *args) -> Optional[dict[str, Any]]:
     """Execute a shell script function with security checks and better error handling.
 
     Args:
@@ -176,7 +176,7 @@ def fatal_error(msg: str) -> None:
 
 
 def execute_os_command(
-    command: Union[str, List[str]],
+    command: Union[str, list[str]],
     fail_on_error: bool = True,
     stdin: Optional[str] = None,
     timeout: Optional[int] = None,
@@ -294,12 +294,12 @@ def execute_os_command(
 
 
 def execute_command_safe(
-    args: List[str],
+    args: list[str],
     fail_on_error: bool = True,
     stdin: Optional[str] = None,
     timeout: Optional[int] = None,
     cwd: Optional[str] = None,
-    env: Optional[Dict[str, str]] = None,
+    env: Optional[dict[str, str]] = None,
     check_executable: bool = True,
 ) -> str:
     """Execute a command safely without shell interpolation.
@@ -414,11 +414,11 @@ def execute_command_safe(
 
 
 def execute_command_with_result(
-    args: List[str],
+    args: list[str],
     stdin: Optional[str] = None,
     timeout: Optional[int] = None,
     cwd: Optional[str] = None,
-    env: Optional[Dict[str, str]] = None,
+    env: Optional[dict[str, str]] = None,
 ) -> CommandResult:
     """Execute a command and return structured result (never raises on non-zero exit).
 

--- a/src/mcli/lib/toml/toml.py
+++ b/src/mcli/lib/toml/toml.py
@@ -26,7 +26,7 @@ def read_from_toml(file_path: str, key: str) -> Optional[Any]:
         # Fall back to the third-party 'toml' package for earlier Python versions.
         import toml
 
-        with open(file_path, "r", encoding="utf-8") as file:
+        with open(file_path, encoding="utf-8") as file:
             config_data = toml.load(file)
 
     # Return the value for the provided key, or None if the key is not found.

--- a/tests/cli/test_self_cmd_utilities.py
+++ b/tests/cli/test_self_cmd_utilities.py
@@ -69,7 +69,7 @@ class TestLockfileUtilities:
                 json.dumps(test_data).splitlines()
             )
 
-            with open(temp_path, "r") as f:
+            with open(temp_path) as f:
                 result = json.load(f)
 
         assert result == test_data

--- a/tests/fixtures/command_fixtures.py
+++ b/tests/fixtures/command_fixtures.py
@@ -29,7 +29,7 @@ class MockCommandResponse:
     duration_ms: float = 10.0
     exception: Optional[Exception] = None
 
-    def to_result(self, command: Optional[List[str]] = None) -> CommandResult:
+    def to_result(self, command: Optional[list[str]] = None) -> CommandResult:
         """Convert to a CommandResult object."""
         return CommandResult(
             returncode=self.returncode,
@@ -299,7 +299,7 @@ def capture_commands():
 
     class CommandCapture:
         def __init__(self):
-            self.commands: List[List[str]] = []
+            self.commands: list[list[str]] = []
             self._patches = []
 
         def _capture(self, args, **kwargs):

--- a/tests/unit/test_custom_commands.py
+++ b/tests/unit/test_custom_commands.py
@@ -63,7 +63,7 @@ class TestCustomCommandManager:
         assert path.name == "test_cmd.json"
 
         # Verify content
-        with open(path, "r") as f:
+        with open(path) as f:
             data = json.load(f)
 
         assert data["name"] == "test_cmd"
@@ -156,7 +156,7 @@ class TestCustomCommandManager:
         assert self.manager.lockfile_path.exists()
 
         # Load and verify
-        with open(self.manager.lockfile_path, "r") as f:
+        with open(self.manager.lockfile_path) as f:
             lockfile = json.load(f)
 
         assert "test_cmd" in lockfile["commands"]
@@ -241,7 +241,7 @@ class TestCustomCommandManager:
         assert export_path.exists()
 
         # Verify exported data
-        with open(export_path, "r") as f:
+        with open(export_path) as f:
             exported = json.load(f)
 
         assert len(exported) == 2
@@ -293,7 +293,7 @@ class TestCustomCommandManager:
         assert results["existing_cmd"] is False
 
         # Verify original code is unchanged
-        with open(self.commands_dir / "existing_cmd.json", "r") as f:
+        with open(self.commands_dir / "existing_cmd.json") as f:
             data = json.load(f)
         assert data["code"] == "original"
 
@@ -322,7 +322,7 @@ class TestCustomCommandManager:
         assert results["existing_cmd"] is True
 
         # Verify code is updated
-        with open(self.commands_dir / "existing_cmd.json", "r") as f:
+        with open(self.commands_dir / "existing_cmd.json") as f:
             data = json.load(f)
         assert data["code"] == "new code"
 

--- a/tests/unit/test_language_suffix.py
+++ b/tests/unit/test_language_suffix.py
@@ -1,0 +1,467 @@
+"""
+Unit tests for language suffix disambiguation.
+
+Tests the colon-delimited suffix system that allows users to disambiguate
+commands when multiple scripts share the same stem (e.g. backup.py and backup.sh).
+
+Covers:
+- parse_command_name() parsing logic
+- find_scripts_by_stem() discovery
+- ScopedWorkflowsGroup.list_commands() with and without duplicates
+- ScopedWorkflowsGroup.get_command() with suffix, without suffix, and ambiguous
+"""
+
+import stat
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from mcli.lib.script_loader import (
+    LANGUAGE_SUFFIXES,
+    LANGUAGE_TO_SUFFIX,
+    ScriptLoader,
+    parse_command_name,
+)
+
+
+class TestParseCommandName:
+    """Test parse_command_name() parsing logic."""
+
+    def test_bare_name(self):
+        """Bare name returns (name, None)."""
+        base, lang = parse_command_name("backup")
+        assert base == "backup"
+        assert lang is None
+
+    def test_python_suffix(self):
+        """'backup:py' → ('backup', 'python')."""
+        base, lang = parse_command_name("backup:py")
+        assert base == "backup"
+        assert lang == "python"
+
+    def test_python_long_suffix(self):
+        """'backup:python' → ('backup', 'python')."""
+        base, lang = parse_command_name("backup:python")
+        assert base == "backup"
+        assert lang == "python"
+
+    def test_shell_suffix(self):
+        """'backup:sh' → ('backup', 'shell')."""
+        base, lang = parse_command_name("backup:sh")
+        assert base == "backup"
+        assert lang == "shell"
+
+    def test_bash_suffix(self):
+        """'backup:bash' → ('backup', 'shell')."""
+        base, lang = parse_command_name("backup:bash")
+        assert base == "backup"
+        assert lang == "shell"
+
+    def test_javascript_suffix(self):
+        """'deploy:js' → ('deploy', 'javascript')."""
+        base, lang = parse_command_name("deploy:js")
+        assert base == "deploy"
+        assert lang == "javascript"
+
+    def test_typescript_suffix(self):
+        """'deploy:ts' → ('deploy', 'typescript')."""
+        base, lang = parse_command_name("deploy:ts")
+        assert base == "deploy"
+        assert lang == "typescript"
+
+    def test_ipynb_suffix(self):
+        """'analysis:ipynb' → ('analysis', 'ipynb')."""
+        base, lang = parse_command_name("analysis:ipynb")
+        assert base == "analysis"
+        assert lang == "ipynb"
+
+    def test_unknown_suffix_treated_as_bare(self):
+        """Unknown suffix is treated as part of the bare name."""
+        base, lang = parse_command_name("backup:xyz")
+        assert base == "backup:xyz"
+        assert lang is None
+
+    def test_rsplit_with_multiple_colons(self):
+        """Only the last colon is split: 'my:cmd:sh' → ('my:cmd', 'shell')."""
+        base, lang = parse_command_name("my:cmd:sh")
+        assert base == "my:cmd"
+        assert lang == "shell"
+
+    def test_case_insensitive_suffix(self):
+        """Suffix matching is case insensitive."""
+        base, lang = parse_command_name("backup:PY")
+        assert base == "backup"
+        assert lang == "python"
+
+    def test_empty_name(self):
+        """Empty string returns ('', None)."""
+        base, lang = parse_command_name("")
+        assert base == ""
+        assert lang is None
+
+    def test_colon_only(self):
+        """':' alone returns (':', None) since empty suffix isn't recognized."""
+        base, lang = parse_command_name(":")
+        assert base == ":"
+        assert lang is None
+
+
+class TestLanguageMappings:
+    """Test that the mapping dictionaries are consistent."""
+
+    def test_language_to_suffix_covers_all_languages(self):
+        """Every unique language in LANGUAGE_SUFFIXES has a reverse mapping."""
+        unique_languages = set(LANGUAGE_SUFFIXES.values())
+        for lang in unique_languages:
+            assert lang in LANGUAGE_TO_SUFFIX, f"Missing reverse mapping for '{lang}'"
+
+    def test_roundtrip(self):
+        """The canonical suffix for each language maps back to that language."""
+        for lang, suffix in LANGUAGE_TO_SUFFIX.items():
+            assert LANGUAGE_SUFFIXES[suffix] == lang
+
+
+class TestFindScriptsByStem:
+    """Test ScriptLoader.find_scripts_by_stem()."""
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.workflows_dir = Path(self.temp_dir) / "workflows"
+        self.workflows_dir.mkdir(parents=True, exist_ok=True)
+        self.loader = ScriptLoader(self.workflows_dir)
+
+    def teardown_method(self):
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _create_script(self, name: str, content: str = "#!/usr/bin/env bash\necho hi\n") -> Path:
+        script_path = self.workflows_dir / name
+        script_path.write_text(content)
+        script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR)
+        return script_path
+
+    def test_finds_both_variants(self):
+        """With backup.py and backup.sh, find_scripts_by_stem('backup') returns both."""
+        self._create_script("backup.py", "#!/usr/bin/env python3\nprint('py')\n")
+        self._create_script("backup.sh", "#!/usr/bin/env bash\necho sh\n")
+
+        matches = self.loader.find_scripts_by_stem("backup")
+        assert len(matches) == 2
+        stems = {p.suffix for p in matches}
+        assert stems == {".py", ".sh"}
+
+    def test_finds_single(self):
+        """With only backup.py, find_scripts_by_stem('backup') returns one."""
+        self._create_script("backup.py", "#!/usr/bin/env python3\nprint('py')\n")
+
+        matches = self.loader.find_scripts_by_stem("backup")
+        assert len(matches) == 1
+        assert matches[0].suffix == ".py"
+
+    def test_no_match(self):
+        """With no matching scripts, returns empty list."""
+        self._create_script("deploy.sh")
+        matches = self.loader.find_scripts_by_stem("backup")
+        assert matches == []
+
+    def test_does_not_match_partial_stem(self):
+        """'back' should not match 'backup.py'."""
+        self._create_script("backup.py", "#!/usr/bin/env python3\nprint('py')\n")
+        matches = self.loader.find_scripts_by_stem("back")
+        assert matches == []
+
+
+class TestWorkflowListCommandsWithDuplicates:
+    """Test ScopedWorkflowsGroup.list_commands() duplicate-aware naming."""
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.workflows_dir = Path(self.temp_dir) / "workflows"
+        self.workflows_dir.mkdir(parents=True, exist_ok=True)
+
+    def teardown_method(self):
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _create_script(self, name: str, content: str) -> Path:
+        script_path = self.workflows_dir / name
+        script_path.write_text(content)
+        script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR)
+        return script_path
+
+    def test_duplicate_stems_get_suffixed(self):
+        """When backup.py and backup.sh exist, list_commands returns backup:py and backup:sh."""
+        from mcli.workflow.workflow import ScopedWorkflowsGroup
+
+        self._create_script(
+            "backup.py",
+            "#!/usr/bin/env python3\nimport click\n@click.command()\ndef backup():\n    pass\n",
+        )
+        self._create_script("backup.sh", "#!/usr/bin/env bash\necho backup\n")
+
+        group = ScopedWorkflowsGroup(name="test")
+
+        # Mock context with workspace pointing to our temp dir
+        ctx = click.Context(group)
+        ctx.params = {"is_global": False, "workspace": None}
+
+        with patch(
+            "mcli.workflow.workflow.ScopedWorkflowsGroup._get_workflows_dir",
+            return_value=self.workflows_dir,
+        ):
+            commands = group.list_commands(ctx)
+
+        assert "backup:py" in commands
+        assert "backup:sh" in commands
+        assert "backup" not in commands
+
+    def test_unique_stem_stays_bare(self):
+        """When only deploy.sh exists, list_commands returns bare 'deploy'."""
+        from mcli.workflow.workflow import ScopedWorkflowsGroup
+
+        self._create_script("deploy.sh", "#!/usr/bin/env bash\necho deploy\n")
+
+        group = ScopedWorkflowsGroup(name="test")
+        ctx = click.Context(group)
+        ctx.params = {"is_global": False, "workspace": None}
+
+        with patch(
+            "mcli.workflow.workflow.ScopedWorkflowsGroup._get_workflows_dir",
+            return_value=self.workflows_dir,
+        ):
+            commands = group.list_commands(ctx)
+
+        assert "deploy" in commands
+        assert "deploy:sh" not in commands
+
+    def test_mixed_unique_and_duplicate(self):
+        """Mix of unique and duplicate stems handled correctly."""
+        from mcli.workflow.workflow import ScopedWorkflowsGroup
+
+        self._create_script(
+            "backup.py",
+            "#!/usr/bin/env python3\nimport click\n@click.command()\ndef backup():\n    pass\n",
+        )
+        self._create_script("backup.sh", "#!/usr/bin/env bash\necho backup\n")
+        self._create_script("deploy.sh", "#!/usr/bin/env bash\necho deploy\n")
+
+        group = ScopedWorkflowsGroup(name="test")
+        ctx = click.Context(group)
+        ctx.params = {"is_global": False, "workspace": None}
+
+        with patch(
+            "mcli.workflow.workflow.ScopedWorkflowsGroup._get_workflows_dir",
+            return_value=self.workflows_dir,
+        ):
+            commands = group.list_commands(ctx)
+
+        assert "backup:py" in commands
+        assert "backup:sh" in commands
+        assert "deploy" in commands
+        assert "deploy:sh" not in commands
+
+
+class TestWorkflowGetCommandWithSuffix:
+    """Test ScopedWorkflowsGroup.get_command() with language suffixes."""
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.workflows_dir = Path(self.temp_dir) / "workflows"
+        self.workflows_dir.mkdir(parents=True, exist_ok=True)
+
+    def teardown_method(self):
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _create_script(self, name: str, content: str) -> Path:
+        script_path = self.workflows_dir / name
+        script_path.write_text(content)
+        script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR)
+        return script_path
+
+    def test_get_command_with_suffix_loads_correct_language(self):
+        """'backup:sh' loads the shell version when both exist."""
+        from mcli.workflow.workflow import ScopedWorkflowsGroup
+
+        self._create_script(
+            "backup.py",
+            "#!/usr/bin/env python3\nimport click\n@click.command()\ndef backup():\n    click.echo('python')\n",
+        )
+        self._create_script("backup.sh", "#!/usr/bin/env bash\necho shell\n")
+
+        group = ScopedWorkflowsGroup(name="test")
+        ctx = click.Context(group)
+        ctx.params = {"is_global": False, "workspace": None}
+
+        with patch(
+            "mcli.workflow.workflow.ScopedWorkflowsGroup._get_workflows_dir",
+            return_value=self.workflows_dir,
+        ):
+            cmd = group.get_command(ctx, "backup:sh")
+
+        assert cmd is not None
+
+    def test_get_command_with_suffix_loads_python(self):
+        """'backup:py' loads the python version when both exist."""
+        from mcli.workflow.workflow import ScopedWorkflowsGroup
+
+        self._create_script(
+            "backup.py",
+            "#!/usr/bin/env python3\nimport click\n@click.command()\ndef backup():\n    click.echo('python')\n",
+        )
+        self._create_script("backup.sh", "#!/usr/bin/env bash\necho shell\n")
+
+        group = ScopedWorkflowsGroup(name="test")
+        ctx = click.Context(group)
+        ctx.params = {"is_global": False, "workspace": None}
+
+        with patch(
+            "mcli.workflow.workflow.ScopedWorkflowsGroup._get_workflows_dir",
+            return_value=self.workflows_dir,
+        ):
+            cmd = group.get_command(ctx, "backup:py")
+
+        assert cmd is not None
+
+    def test_get_command_bare_name_single_match(self):
+        """Bare name with single match loads directly, no warning."""
+        from mcli.workflow.workflow import ScopedWorkflowsGroup
+
+        self._create_script("deploy.sh", "#!/usr/bin/env bash\necho deploy\n")
+
+        group = ScopedWorkflowsGroup(name="test")
+        ctx = click.Context(group)
+        ctx.params = {"is_global": False, "workspace": None}
+
+        with patch(
+            "mcli.workflow.workflow.ScopedWorkflowsGroup._get_workflows_dir",
+            return_value=self.workflows_dir,
+        ):
+            cmd = group.get_command(ctx, "deploy")
+
+        assert cmd is not None
+
+    def test_get_command_bare_name_multiple_matches_shows_warning(self):
+        """Bare name with multiple matches shows warning and returns first."""
+        from mcli.workflow.workflow import ScopedWorkflowsGroup
+
+        self._create_script(
+            "backup.py",
+            "#!/usr/bin/env python3\nimport click\n@click.command()\ndef backup():\n    click.echo('python')\n",
+        )
+        self._create_script("backup.sh", "#!/usr/bin/env bash\necho shell\n")
+
+        group = ScopedWorkflowsGroup(name="test")
+        ctx = click.Context(group)
+        ctx.params = {"is_global": False, "workspace": None}
+
+        with (
+            patch(
+                "mcli.workflow.workflow.ScopedWorkflowsGroup._get_workflows_dir",
+                return_value=self.workflows_dir,
+            ),
+            patch("mcli.lib.ui.styling.warning") as mock_warning,
+        ):
+            cmd = group.get_command(ctx, "backup")
+
+        assert cmd is not None
+        mock_warning.assert_called_once()
+        warning_msg = mock_warning.call_args[0][0]
+        assert "backup:py" in warning_msg or "backup:sh" in warning_msg
+
+    def test_get_command_no_match(self):
+        """Non-existent command returns None."""
+        from mcli.workflow.workflow import ScopedWorkflowsGroup
+
+        self._create_script("deploy.sh", "#!/usr/bin/env bash\necho deploy\n")
+
+        group = ScopedWorkflowsGroup(name="test")
+        ctx = click.Context(group)
+        ctx.params = {"is_global": False, "workspace": None}
+
+        with patch(
+            "mcli.workflow.workflow.ScopedWorkflowsGroup._get_workflows_dir",
+            return_value=self.workflows_dir,
+        ):
+            cmd = group.get_command(ctx, "nonexistent")
+
+        assert cmd is None
+
+    def test_get_command_suffix_filters_to_nonexistent_language(self):
+        """'backup:js' when only .py and .sh exist returns None."""
+        from mcli.workflow.workflow import ScopedWorkflowsGroup
+
+        self._create_script(
+            "backup.py",
+            "#!/usr/bin/env python3\nimport click\n@click.command()\ndef backup():\n    click.echo('python')\n",
+        )
+        self._create_script("backup.sh", "#!/usr/bin/env bash\necho shell\n")
+
+        group = ScopedWorkflowsGroup(name="test")
+        ctx = click.Context(group)
+        ctx.params = {"is_global": False, "workspace": None}
+
+        with patch(
+            "mcli.workflow.workflow.ScopedWorkflowsGroup._get_workflows_dir",
+            return_value=self.workflows_dir,
+        ):
+            cmd = group.get_command(ctx, "backup:js")
+
+        assert cmd is None
+
+
+class TestApplyDisplayNames:
+    """Test the _apply_display_names helper in list_cmd."""
+
+    def test_unique_names_stay_bare(self):
+        from mcli.app.list_cmd import _apply_display_names
+
+        workflows = [
+            {"name": "deploy", "language": "shell"},
+            {"name": "backup", "language": "python"},
+        ]
+        _apply_display_names(workflows)
+        assert workflows[0]["display_name"] == "deploy"
+        assert workflows[1]["display_name"] == "backup"
+
+    def test_duplicate_names_get_suffixed(self):
+        from mcli.app.list_cmd import _apply_display_names
+
+        workflows = [
+            {"name": "backup", "language": "python"},
+            {"name": "backup", "language": "shell"},
+        ]
+        _apply_display_names(workflows)
+        assert workflows[0]["display_name"] == "backup:py"
+        assert workflows[1]["display_name"] == "backup:sh"
+
+    def test_mixed_unique_and_duplicate(self):
+        from mcli.app.list_cmd import _apply_display_names
+
+        workflows = [
+            {"name": "backup", "language": "python"},
+            {"name": "backup", "language": "shell"},
+            {"name": "deploy", "language": "shell"},
+        ]
+        _apply_display_names(workflows)
+        assert workflows[0]["display_name"] == "backup:py"
+        assert workflows[1]["display_name"] == "backup:sh"
+        assert workflows[2]["display_name"] == "deploy"
+
+    def test_unknown_language_uses_question_mark(self):
+        from mcli.app.list_cmd import _apply_display_names
+
+        workflows = [
+            {"name": "mystery", "language": "unknown_lang"},
+            {"name": "mystery", "language": "python"},
+        ]
+        _apply_display_names(workflows)
+        assert workflows[0]["display_name"] == "mystery:?"
+        assert workflows[1]["display_name"] == "mystery:py"


### PR DESCRIPTION
## Summary

Resolves the command name collision issue where multiple scripts with the same stem (e.g. `backup.py` and `backup.sh`) silently shadow each other. Now:

- **`mcli list`** shows suffixed names (`backup:py`, `backup:sh`) when duplicates exist
- **`mcli run backup:py`** explicitly selects the Python version
- **`mcli run backup`** still works when unambiguous; shows a warning with options when ambiguous

## Changes

- `script_loader.py`: New `parse_command_name()`, `LANGUAGE_SUFFIXES`/`LANGUAGE_TO_SUFFIX` maps, `find_scripts_by_stem()`
- `workflow.py`: Updated `list_commands()` and `get_command()` for suffix-aware resolution
- `list_cmd.py`: New `_apply_display_names()` for Rich table display
- `messages.py`: Added `AMBIGUOUS_COMMAND` warning constant
- Minor type hint modernization (`Dict`→`dict`, `List`→`list`) in touched files
- 32 new unit tests across 7 test classes

## Test plan

- [x] 32 new unit tests pass (`tests/unit/test_language_suffix.py`)
- [x] Full unit suite: 1177 passed, 53 skipped (32 pre-existing async failures, unrelated)
- [x] Black formatting clean
- [ ] CI pipeline passes

## Summary by Sourcery

Introduce language-suffix-aware workflow command discovery and execution to disambiguate scripts sharing the same command name.

New Features:
- Add colon-delimited language suffix parsing for command names (e.g. 'backup:py', 'backup:sh') to disambiguate scripts with the same stem.
- Expose suffixed workflow names in CLI listing output when duplicate stems exist, including JSON and Rich table views.

Enhancements:
- Extend workflow command resolution to prefer specific language variants when suffixed, handle ambiguous bare names with a user warning, and fall back cleanly to legacy JSON commands.
- Add language suffix mapping utilities and suffix-aware script discovery helpers to the script loader.
- Improve type hints and built-in collection usage across logger, shell utilities, fixtures, and TOML helpers.
- Clean up CLAUDE documentation and release notes reference.

Tests:
- Add a comprehensive unit test suite for language suffix parsing, duplicate-aware listing, suffix-based command resolution, and display-name handling.