### PR TITLE
chore: Bump version to 8.0.38 for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcli-framework"
-version = "8.0.37"
+version = "8.0.38"
 description = "Portable workflow framework - transform any script into a versioned, schedulable command. Store in ~/.mcli/workflows/, version with lockfile, run as daemon or cron job."
 readme = "README.md"
  requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bump version from 8.0.37 → 8.0.38 to publish language suffix disambiguation feature

## Test plan

- [x] Version string updated in pyproject.toml
- [ ] CI passes
- [ ] PyPI publish triggers on merge to main