### PR TITLE
feat: Rename local .mcli/ to mcli/ with backward compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcli-framework"
-version = "8.0.39"
+version = "8.0.40"
 description = "Portable workflow framework - transform any script into a versioned, schedulable command. Store in ~/.mcli/workflows/, version with lockfile, run as daemon or cron job."
 readme = "README.md"
  requires-python = ">=3.10"

--- a/src/mcli/app/init_cmd.py
+++ b/src/mcli/app/init_cmd.py
@@ -30,11 +30,11 @@ def init(is_global, git, force):
     """🚀 Initialize workflows directory structure.
 
     Creates the necessary directories and configuration files for managing
-    custom workflows. By default, creates a local .mcli/workflows/ directory
+    custom workflows. By default, creates a local mcli/workflows/ directory
     in the current directory.
 
     Examples:
-        mcli init              # Initialize local .mcli/workflows/ in current directory
+        mcli init              # Initialize local mcli/workflows/ in current directory
         mcli init --global     # Initialize global ~/.mcli/workflows/
         mcli init --git        # Also initialize git repository
     """
@@ -50,11 +50,13 @@ def init(is_global, git, force):
         workflows_dir = get_mcli_home() / "workflows"
         is_local = False
     else:
-        # Local: .mcli/workflows in current directory (default behavior)
+        # Local: mcli/workflows in current directory (default behavior)
         from pathlib import Path
 
+        from mcli.lib.constants.paths import DirNames
+
         cwd = Path.cwd()
-        workflows_dir = cwd / ".mcli" / "workflows"
+        workflows_dir = cwd / DirNames.LOCAL_MCLI / "workflows"
         is_local = True
 
     lockfile_path = workflows_dir / "commands.lock.json"

--- a/src/mcli/lib/constants/env.py
+++ b/src/mcli/lib/constants/env.py
@@ -68,5 +68,8 @@ class EnvVars:
     MCLI_USE_SYSTEM_PYTHON = "MCLI_USE_SYSTEM_PYTHON"  # Skip venv detection
     MCLI_VENV_PATH = "MCLI_VENV_PATH"  # Override venv path
 
+    # Local workspace directory override
+    MCLI_LOCAL_DIR = "MCLI_LOCAL_DIR"  # Override local workspace dir name
+
 
 __all__ = ["EnvVars"]

--- a/src/mcli/lib/constants/messages.py
+++ b/src/mcli/lib/constants/messages.py
@@ -59,6 +59,10 @@ class WarningMessages:
     RATE_LIMIT_WARNING = "Approaching rate limit for {service}"
     LARGE_FILE_WARNING = "Large file detected: {path} ({size})"
     AMBIGUOUS_COMMAND = "Multiple versions of '{name}' found. Specify language: {options}"
+    DEPRECATED_LOCAL_DIR = (
+        "[yellow]Using legacy '.mcli/' directory. "
+        "Run 'mcli self migrate --rename-dir' to upgrade to 'mcli/'.[/yellow]"
+    )
 
 
 class InfoMessages:

--- a/src/mcli/lib/constants/paths.py
+++ b/src/mcli/lib/constants/paths.py
@@ -8,7 +8,9 @@ Using these constants ensures consistency across the codebase.
 class DirNames:
     """Directory name constants."""
 
-    MCLI = ".mcli"
+    MCLI = ".mcli"  # Global home (~/.mcli) — UNCHANGED
+    LOCAL_MCLI = "mcli"  # New local workspace dir (visible in IDE/ls)
+    LEGACY_LOCAL_MCLI = ".mcli"  # Legacy local dir (for fallback)
     GIT = ".git"
     LOGS = "logs"
     CONFIG = "config"

--- a/src/mcli/lib/paths.py
+++ b/src/mcli/lib/paths.py
@@ -158,16 +158,45 @@ def get_git_root(path: Optional[Path] = None) -> Optional[Path]:
 
 def get_local_mcli_dir() -> Optional[Path]:
     """
-    Get the local .mcli directory for the current git repository.
+    Get the local mcli workspace directory for the current git repository.
+
+    Resolution order:
+    1. MCLI_LOCAL_DIR env var override
+    2. New 'mcli/' directory (visible in IDE/ls)
+    3. Legacy '.mcli/' directory (with deprecation warning)
+    4. Default to new 'mcli/' path (for fresh init)
 
     Returns:
-        Path to .mcli directory in git root, or None if not in a git repository
+        Path to local mcli directory in git root, or None if not in a git repository
     """
     git_root = get_git_root()
-    if git_root:
-        local_mcli = git_root / DirNames.MCLI
-        return local_mcli
-    return None
+    if not git_root:
+        return None
+
+    # 1. Check MCLI_LOCAL_DIR env var override
+    custom_dir = os.environ.get("MCLI_LOCAL_DIR")
+    if custom_dir:
+        return git_root / custom_dir
+
+    # 2. Check new "mcli/" directory
+    new_dir = git_root / DirNames.LOCAL_MCLI
+    if new_dir.exists():
+        return new_dir
+
+    # 3. Fall back to legacy ".mcli/"
+    legacy_dir = git_root / DirNames.LEGACY_LOCAL_MCLI
+    if legacy_dir.exists():
+        import warnings
+
+        warnings.warn(
+            "Using legacy '.mcli/' directory. " "Run 'mcli self migrate --rename-dir' to upgrade.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return legacy_dir
+
+    # 4. Neither exists — return new path (for fresh init)
+    return git_root / DirNames.LOCAL_MCLI
 
 
 def get_local_commands_dir() -> Optional[Path]:
@@ -257,7 +286,7 @@ def resolve_workspace(workspace_path: str) -> Optional[Path]:
     Resolve a workspace path to a workflows directory.
 
     Accepts either:
-    - A directory path (uses <dir>/.mcli/workflows/)
+    - A directory path (uses <dir>/mcli/workflows/ or <dir>/.mcli/workflows/)
     - A config file path (parses for workflows location)
 
     Args:
@@ -271,20 +300,19 @@ def resolve_workspace(workspace_path: str) -> Optional[Path]:
     if not path.exists():
         return None
 
-    # If it's a directory, look for .mcli/workflows/ inside it
+    # If it's a directory, look for mcli/workflows/ or .mcli/workflows/ inside it
     if path.is_dir():
-        # Check for .mcli/workflows/
-        workflows_dir = path / DirNames.MCLI / "workflows"
-        if workflows_dir.exists():
-            return workflows_dir
+        # Check new mcli/ first, then legacy .mcli/
+        for dir_name in [DirNames.LOCAL_MCLI, DirNames.LEGACY_LOCAL_MCLI]:
+            workflows_dir = path / dir_name / "workflows"
+            if workflows_dir.exists():
+                return workflows_dir
+            commands_dir = path / dir_name / "commands"
+            if commands_dir.exists():
+                return commands_dir
 
-        # Check for legacy .mcli/commands/
-        commands_dir = path / DirNames.MCLI / "commands"
-        if commands_dir.exists():
-            return commands_dir
-
-        # If neither exists, return the expected workflows path
-        return workflows_dir
+        # If neither exists, return the expected new path
+        return path / DirNames.LOCAL_MCLI / "workflows"
 
     # If it's a file, try to parse it as a config file
     if path.is_file():

--- a/src/mcli/lib/workspace_registry.py
+++ b/src/mcli/lib/workspace_registry.py
@@ -12,11 +12,29 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from mcli.lib.constants.paths import DirNames
 from mcli.lib.logger.logger import get_logger
 from mcli.lib.paths import get_git_root, get_mcli_home, is_git_repository
 from mcli.lib.script_loader import ScriptLoader
 
 logger = get_logger(__name__)
+
+
+def _resolve_local_workflows(workspace_path: Path) -> Optional[Path]:
+    """Find the workflows dir in a workspace, checking new and legacy paths."""
+    for dir_name in [DirNames.LOCAL_MCLI, DirNames.LEGACY_LOCAL_MCLI]:
+        workflows_dir = workspace_path / dir_name / "workflows"
+        if workflows_dir.exists():
+            return workflows_dir
+        commands_dir = workspace_path / dir_name / "commands"
+        if commands_dir.exists():
+            return commands_dir
+    return None
+
+
+def _local_workflows_exist(workspace_path: Path) -> bool:
+    """Check if any local workflows directory exists in a workspace."""
+    return _resolve_local_workflows(workspace_path) is not None
 
 
 def get_registry_path() -> Path:
@@ -105,15 +123,11 @@ def register_workspace(
 
     workspace_path = workspace_path.resolve()
 
-    # Check if workflows directory exists
-    workflows_dir = workspace_path / ".mcli" / "workflows"
-    if not workflows_dir.exists():
-        # Also check for legacy commands directory
-        legacy_dir = workspace_path / ".mcli" / "commands"
-        if not legacy_dir.exists():
-            logger.warning(f"No workflows found at {workspace_path}")
-            logger.info("Initialize with: mcli init")
-            return None
+    # Check if workflows directory exists (new mcli/ or legacy .mcli/)
+    if not _local_workflows_exist(workspace_path):
+        logger.warning(f"No workflows found at {workspace_path}")
+        logger.info("Initialize with: mcli init")
+        return None
 
     # Load registry
     registry = load_registry()
@@ -191,9 +205,7 @@ def list_registered_workspaces() -> List[Dict[str, Any]]:
         workspace_path = Path(workspace_data["path"])
 
         # Check if workspace still exists
-        workflows_dir = workspace_path / ".mcli" / "workflows"
-        legacy_dir = workspace_path / ".mcli" / "commands"
-        exists = workflows_dir.exists() or legacy_dir.exists()
+        exists = _local_workflows_exist(workspace_path)
 
         workspaces.append(
             {
@@ -242,12 +254,9 @@ def get_all_workflows() -> Dict[str, List[Dict[str, Any]]]:
         workspace_path = Path(workspace_data["path"])
         workspace_name = workspace_data.get("name", workspace_path.name)
 
-        # Determine workflows directory
-        workflows_dir = workspace_path / ".mcli" / "workflows"
-        if not workflows_dir.exists():
-            workflows_dir = workspace_path / ".mcli" / "commands"
-
-        if not workflows_dir.exists():
+        # Determine workflows directory (check new mcli/ then legacy .mcli/)
+        workflows_dir = _resolve_local_workflows(workspace_path)
+        if workflows_dir is None:
             continue
 
         loader = ScriptLoader(workflows_dir)
@@ -290,11 +299,8 @@ def auto_register_current() -> Optional[str]:
     if workspace_id in registry.get("workspaces", {}):
         return workspace_id
 
-    # Check if has workflows
-    workflows_dir = git_root / ".mcli" / "workflows"
-    legacy_dir = git_root / ".mcli" / "commands"
-
-    if workflows_dir.exists() or legacy_dir.exists():
+    # Check if has workflows (new mcli/ or legacy .mcli/)
+    if _local_workflows_exist(git_root):
         return register_workspace(git_root)
 
     return None

--- a/src/mcli/self/env_cmd.py
+++ b/src/mcli/self/env_cmd.py
@@ -175,8 +175,17 @@ def env_command(
     # Get workflows directory for this workspace
     _workflows_dir = get_custom_commands_dir(global_mode=False)  # noqa: F841
     if workspace_dir and is_git_repository():
-        local_workflows = workspace_dir / ".mcli" / "workflows"
-        if local_workflows.exists():
+        from mcli.lib.constants.paths import DirNames
+
+        # Check both new mcli/ and legacy .mcli/ local dir
+        local_workflows = None
+        for dir_name in [DirNames.LOCAL_MCLI, DirNames.LEGACY_LOCAL_MCLI]:
+            candidate = workspace_dir / dir_name / "workflows"
+            if candidate.exists():
+                local_workflows = candidate
+                break
+
+        if local_workflows is not None:
             env_info["workflows_dir"] = str(local_workflows)
             # Count workflow scripts
             script_count = sum(

--- a/src/mcli/self/migrate_cmd.py
+++ b/src/mcli/self/migrate_cmd.py
@@ -194,6 +194,11 @@ def get_migration_status() -> dict:
             local_old = git_root / DirNames.MCLI / "commands"
             local_new = git_root / DirNames.MCLI / "workflows"
 
+            # Check if local dir needs rename (.mcli/ → mcli/)
+            legacy_local = git_root / DirNames.LEGACY_LOCAL_MCLI
+            new_local = git_root / DirNames.LOCAL_MCLI
+            needs_dir_rename = legacy_local.exists() and not new_local.exists()
+
             local_status: dict = {
                 "git_root": str(git_root),
                 "old_dir_exists": local_old.exists(),
@@ -203,6 +208,7 @@ def get_migration_status() -> dict:
                 "needs_migration": False,
                 "files_to_migrate": [],
                 "migration_done": False,
+                "needs_dir_rename": needs_dir_rename,
             }
             status["local"] = local_status
 
@@ -411,6 +417,11 @@ def migrate_commands_to_workflows(
     is_flag=True,
     help="Remove JSON files after successful conversion (use with --json-to-scripts)",
 )
+@click.option(
+    "--rename-dir",
+    is_flag=True,
+    help="Rename local '.mcli/' directories to 'mcli/' in current git repo",
+)
 def migrate_command(
     dry_run: bool,
     force: bool,
@@ -420,6 +431,7 @@ def migrate_command(
     description: str,
     json_to_scripts: bool,
     remove_json: bool,
+    rename_dir: bool,
 ):
     """
     Migrate mcli configuration and data to new structure.
@@ -427,6 +439,7 @@ def migrate_command(
     Currently handles:
     - Moving ~/.mcli/commands to ~/.mcli/workflows (global)
     - Moving .mcli/commands to .mcli/workflows (local, in git repos)
+    - Renaming local .mcli/ to mcli/ for visibility (--rename-dir)
     - Converting JSON workflow files to native scripts (--json-to-scripts)
     - Optionally pushing to IPFS for decentralized backup
 
@@ -437,6 +450,7 @@ def migrate_command(
         mcli self migrate --scope global     # Migrate only global
         mcli self migrate --scope local      # Migrate only local (current repo)
         mcli self migrate --force            # Force migration (overwrite existing)
+        mcli self migrate --rename-dir       # Rename .mcli/ to mcli/ in current repo
         mcli self migrate --json-to-scripts  # Convert JSON workflows to scripts
         mcli self migrate --to-ipfs -d "Migrated workflows v1.0"  # Push to IPFS after
     """
@@ -481,6 +495,12 @@ def migrate_command(
             else:
                 console.print("  [green]✓ No migration needed[/green]")
 
+            if local_status.get("needs_dir_rename"):
+                console.print(
+                    "  [yellow]⚠ Directory rename needed: "
+                    ".mcli/ → mcli/ (run --rename-dir)[/yellow]"
+                )
+
         # Show files to migrate if any
         all_files = global_status.get("files_to_migrate", [])
         if migration_status["local"]:
@@ -502,6 +522,43 @@ def migrate_command(
             console.print(table)
             console.print("\n[dim]Run 'mcli self migrate' to perform migration[/dim]")
 
+        return
+
+    # Handle --rename-dir: rename local .mcli/ → mcli/
+    if rename_dir:
+        from mcli.lib.paths import get_git_root, is_git_repository
+
+        if not is_git_repository():
+            error("Not in a git repository")
+            return
+
+        git_root = get_git_root()
+        if not git_root:
+            error("Could not determine git root")
+            return
+
+        old_dir = git_root / DirNames.LEGACY_LOCAL_MCLI  # .mcli
+        new_dir = git_root / DirNames.LOCAL_MCLI  # mcli
+
+        if new_dir.exists() and not old_dir.exists():
+            info("Already using 'mcli/' directory — no migration needed")
+            return
+
+        if not old_dir.exists():
+            info("No '.mcli/' directory found — nothing to migrate")
+            return
+
+        if new_dir.exists() and old_dir.exists():
+            error("Both 'mcli/' and '.mcli/' exist. Resolve manually.")
+            return
+
+        if dry_run:
+            console.print(f"[yellow]Would rename:[/yellow] {old_dir} → {new_dir}")
+            return
+
+        shutil.move(str(old_dir), str(new_dir))
+        success(f"Renamed '{old_dir.name}/' → '{new_dir.name}/'")
+        console.print("[dim]Tip: Update your .gitignore if it references .mcli/[/dim]")
         return
 
     # Handle --json-to-scripts conversion

--- a/tests/integration/test_all_commands_comprehensive.py
+++ b/tests/integration/test_all_commands_comprehensive.py
@@ -42,8 +42,8 @@ def mock_repo(tmp_path):
     repo_dir = tmp_path / "mock_repo"
     repo_dir.mkdir()
 
-    # Create .mcli directory structure
-    mcli_dir = repo_dir / ".mcli"
+    # Create mcli directory structure (local workspace)
+    mcli_dir = repo_dir / "mcli"
     mcli_dir.mkdir()
 
     commands_dir = mcli_dir / "commands"

--- a/tests/unit/test_init_mv_cmd.py
+++ b/tests/unit/test_init_mv_cmd.py
@@ -1,7 +1,7 @@
 """Unit tests for mcli init and mv commands.
 
 Tests the new behaviors added in v8.0.26:
-- mcli init defaults to local .mcli/workflows in current directory
+- mcli init defaults to local mcli/workflows in current directory
 - mcli mv auto-detects directory paths as workspace destinations
 """
 
@@ -31,13 +31,13 @@ class TestInitCommand:
         return tmp_path
 
     def test_init_defaults_to_local(self, cli_runner, temp_dir):
-        """Test that mcli init creates local .mcli/workflows by default."""
+        """Test that mcli init creates local mcli/workflows by default."""
         with cli_runner.isolated_filesystem(temp_dir=temp_dir):
             result = cli_runner.invoke(init, [])
 
             assert result.exit_code == 0
-            assert Path(".mcli/workflows").exists()
-            assert Path(".mcli/workflows/commands.lock.json").exists()
+            assert Path("mcli/workflows").exists()
+            assert Path("mcli/workflows/commands.lock.json").exists()
             assert "Local (directory-specific)" in result.output
 
     def test_init_global_flag_uses_home(self, cli_runner, temp_dir):
@@ -59,7 +59,7 @@ class TestInitCommand:
 
             assert result.exit_code == 0
 
-            lockfile_path = Path(".mcli/workflows/commands.lock.json")
+            lockfile_path = Path("mcli/workflows/commands.lock.json")
             with open(lockfile_path) as f:
                 lockfile = json.load(f)
 
@@ -87,7 +87,7 @@ class TestInitCommand:
             result = cli_runner.invoke(init, [])
 
             assert result.exit_code == 0
-            assert Path(".mcli/workflows/README.md").exists()
+            assert Path("mcli/workflows/README.md").exists()
 
     def test_init_creates_gitignore(self, cli_runner, temp_dir):
         """Test that init creates a .gitignore file."""
@@ -95,7 +95,7 @@ class TestInitCommand:
             result = cli_runner.invoke(init, [])
 
             assert result.exit_code == 0
-            assert Path(".mcli/workflows/.gitignore").exists()
+            assert Path("mcli/workflows/.gitignore").exists()
 
     def test_init_force_reinitializes(self, cli_runner, temp_dir):
         """Test that --force flag allows reinitialization."""
@@ -134,7 +134,7 @@ class TestMvCommand:
     def setup_workflows(self, tmp_path):
         """Create a mock workflow setup for testing."""
         # Create source workflows directory with a test command
-        workflows_dir = tmp_path / ".mcli" / "workflows"
+        workflows_dir = tmp_path / "mcli" / "workflows"
         workflows_dir.mkdir(parents=True)
 
         # Create a test command file
@@ -152,7 +152,7 @@ class TestMvCommand:
         # Setup source
         source_dir = tmp_path / "source"
         source_dir.mkdir()
-        source_workflows = source_dir / ".mcli" / "workflows"
+        source_workflows = source_dir / "mcli" / "workflows"
         source_workflows.mkdir(parents=True)
 
         test_cmd = source_workflows / "my-cmd.py"
@@ -172,7 +172,7 @@ class TestMvCommand:
             result = cli_runner.invoke(mv, ["my-cmd", str(dest_dir) + "/"], input="y\n")
 
             # Should recognize it's a directory and try to move there
-            # The command may fail because dest doesn't have .mcli/workflows but
+            # The command may fail because dest doesn't have mcli/workflows but
             # the important thing is it recognized the directory path
             assert "destination" in result.output.lower() or "workspace" in result.output.lower()
 
@@ -181,7 +181,7 @@ class TestMvCommand:
         # This tests the path detection logic
         source_dir = tmp_path / "source"
         source_dir.mkdir()
-        source_workflows = source_dir / ".mcli" / "workflows"
+        source_workflows = source_dir / "mcli" / "workflows"
         source_workflows.mkdir(parents=True)
 
         test_cmd = source_workflows / "my-cmd.py"
@@ -204,7 +204,7 @@ class TestMvCommand:
         """Test that providing both directory path and -w option fails."""
         source_dir = tmp_path / "source"
         source_dir.mkdir()
-        source_workflows = source_dir / ".mcli" / "workflows"
+        source_workflows = source_dir / "mcli" / "workflows"
         source_workflows.mkdir(parents=True)
 
         test_cmd = source_workflows / "my-cmd.py"
@@ -236,7 +236,7 @@ class TestMvCommand:
         # Setup source
         source_dir = tmp_path / "source"
         source_dir.mkdir()
-        source_workflows = source_dir / ".mcli" / "workflows"
+        source_workflows = source_dir / "mcli" / "workflows"
         source_workflows.mkdir(parents=True)
 
         test_cmd = source_workflows / "original-name.py"
@@ -245,10 +245,10 @@ class TestMvCommand:
         lockfile = source_workflows / "commands.lock.json"
         lockfile.write_text(json.dumps({"version": "1.0", "scope": "local", "commands": {}}))
 
-        # Setup destination with .mcli/workflows
+        # Setup destination with mcli/workflows
         dest_dir = tmp_path / "destination"
         dest_dir.mkdir()
-        dest_workflows = dest_dir / ".mcli" / "workflows"
+        dest_workflows = dest_dir / "mcli" / "workflows"
         dest_workflows.mkdir(parents=True)
 
         dest_lockfile = dest_workflows / "commands.lock.json"
@@ -275,7 +275,7 @@ class TestMvCommandRename:
 
     def test_mv_same_source_dest_no_change(self, cli_runner, tmp_path):
         """Test that mv with same source and dest does nothing."""
-        workflows_dir = tmp_path / ".mcli" / "workflows"
+        workflows_dir = tmp_path / "mcli" / "workflows"
         workflows_dir.mkdir(parents=True)
 
         test_cmd = workflows_dir / "my-cmd.py"

--- a/tests/unit/test_migrate_rename_dir.py
+++ b/tests/unit/test_migrate_rename_dir.py
@@ -1,0 +1,104 @@
+"""Unit tests for mcli self migrate --rename-dir functionality."""
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from mcli.self.migrate_cmd import migrate_command
+
+
+class TestMigrateRenameDir:
+    """Tests for the --rename-dir flag on mcli self migrate."""
+
+    @pytest.fixture
+    def cli_runner(self):
+        return CliRunner()
+
+    def test_rename_dir_success(self, cli_runner, tmp_path):
+        """Test successful rename of .mcli/ to mcli/."""
+        (tmp_path / ".git").mkdir()
+        old_dir = tmp_path / ".mcli"
+        old_dir.mkdir()
+        (old_dir / "workflows").mkdir()
+        (old_dir / "workflows" / "test.py").write_text("print('hi')")
+
+        with patch("mcli.lib.paths.is_git_repository", return_value=True):
+            with patch("mcli.lib.paths.get_git_root", return_value=tmp_path):
+                result = cli_runner.invoke(migrate_command, ["--rename-dir"])
+
+        assert result.exit_code == 0
+        assert "Renamed" in result.output
+        assert not old_dir.exists()
+        assert (tmp_path / "mcli").exists()
+        assert (tmp_path / "mcli" / "workflows" / "test.py").exists()
+
+    def test_rename_dir_dry_run(self, cli_runner, tmp_path):
+        """Test --rename-dir with --dry-run shows what would happen."""
+        (tmp_path / ".git").mkdir()
+        old_dir = tmp_path / ".mcli"
+        old_dir.mkdir()
+
+        with patch("mcli.lib.paths.is_git_repository", return_value=True):
+            with patch("mcli.lib.paths.get_git_root", return_value=tmp_path):
+                result = cli_runner.invoke(migrate_command, ["--rename-dir", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "Would rename" in result.output
+        assert old_dir.exists()  # Not actually renamed
+
+    def test_rename_dir_already_migrated(self, cli_runner, tmp_path):
+        """Test --rename-dir when mcli/ already exists and .mcli/ doesn't."""
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "mcli").mkdir()
+
+        with patch("mcli.lib.paths.is_git_repository", return_value=True):
+            with patch("mcli.lib.paths.get_git_root", return_value=tmp_path):
+                result = cli_runner.invoke(migrate_command, ["--rename-dir"])
+
+        assert result.exit_code == 0
+        assert "Already using" in result.output
+
+    def test_rename_dir_no_mcli_dir(self, cli_runner, tmp_path):
+        """Test --rename-dir when no .mcli/ directory exists."""
+        (tmp_path / ".git").mkdir()
+
+        with patch("mcli.lib.paths.is_git_repository", return_value=True):
+            with patch("mcli.lib.paths.get_git_root", return_value=tmp_path):
+                result = cli_runner.invoke(migrate_command, ["--rename-dir"])
+
+        assert result.exit_code == 0
+        assert "nothing to migrate" in result.output.lower()
+
+    def test_rename_dir_both_exist(self, cli_runner, tmp_path):
+        """Test --rename-dir when both mcli/ and .mcli/ exist."""
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".mcli").mkdir()
+        (tmp_path / "mcli").mkdir()
+
+        with patch("mcli.lib.paths.is_git_repository", return_value=True):
+            with patch("mcli.lib.paths.get_git_root", return_value=tmp_path):
+                result = cli_runner.invoke(migrate_command, ["--rename-dir"])
+
+        assert result.exit_code == 0
+        assert "Both" in result.output
+
+    def test_rename_dir_not_in_git_repo(self, cli_runner, tmp_path):
+        """Test --rename-dir when not in a git repository."""
+        with patch("mcli.lib.paths.is_git_repository", return_value=False):
+            result = cli_runner.invoke(migrate_command, ["--rename-dir"])
+
+        assert result.exit_code == 0
+        assert "Not in a git repository" in result.output
+
+    def test_migration_status_shows_dir_rename_needed(self, cli_runner, tmp_path):
+        """Test --status shows directory rename needed."""
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".mcli" / "workflows").mkdir(parents=True)
+
+        with patch("mcli.lib.paths.is_git_repository", return_value=True):
+            with patch("mcli.lib.paths.get_git_root", return_value=tmp_path):
+                result = cli_runner.invoke(migrate_command, ["--status"])
+
+        assert result.exit_code == 0
+        assert "rename" in result.output.lower()

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -198,5 +198,110 @@ class TestPathResolution:
                 assert result.exists()
 
 
+class TestLocalMcliDir:
+    """Test suite for local mcli directory resolution with fallback."""
+
+    def test_get_local_mcli_dir_prefers_new_dir(self, tmp_path):
+        """Test that mcli/ is preferred over .mcli/ when both exist."""
+        from mcli.lib.paths import get_local_mcli_dir
+
+        # Create a fake git repo
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "mcli").mkdir()
+        (tmp_path / ".mcli").mkdir()
+
+        with patch("mcli.lib.paths.get_git_root", return_value=tmp_path):
+            with patch.dict(os.environ, {}, clear=False):
+                # Remove MCLI_LOCAL_DIR if set
+                os.environ.pop("MCLI_LOCAL_DIR", None)
+                result = get_local_mcli_dir()
+
+        assert result == tmp_path / "mcli"
+
+    def test_get_local_mcli_dir_falls_back_to_legacy(self, tmp_path):
+        """Test that .mcli/ is used when mcli/ doesn't exist."""
+        import warnings
+
+        from mcli.lib.paths import get_local_mcli_dir
+
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".mcli").mkdir()
+
+        with patch("mcli.lib.paths.get_git_root", return_value=tmp_path):
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("MCLI_LOCAL_DIR", None)
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always")
+                    result = get_local_mcli_dir()
+
+                    assert result == tmp_path / ".mcli"
+                    assert len(w) == 1
+                    assert "legacy" in str(w[0].message).lower()
+
+    def test_get_local_mcli_dir_defaults_to_new(self, tmp_path):
+        """Test that mcli/ is returned for fresh repos with no existing dir."""
+        from mcli.lib.paths import get_local_mcli_dir
+
+        (tmp_path / ".git").mkdir()
+
+        with patch("mcli.lib.paths.get_git_root", return_value=tmp_path):
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("MCLI_LOCAL_DIR", None)
+                result = get_local_mcli_dir()
+
+        assert result == tmp_path / "mcli"
+
+    def test_get_local_mcli_dir_env_override(self, tmp_path):
+        """Test that MCLI_LOCAL_DIR env var overrides default."""
+        from mcli.lib.paths import get_local_mcli_dir
+
+        (tmp_path / ".git").mkdir()
+
+        with patch("mcli.lib.paths.get_git_root", return_value=tmp_path):
+            with patch.dict(os.environ, {"MCLI_LOCAL_DIR": "custom_workflows"}):
+                result = get_local_mcli_dir()
+
+        assert result == tmp_path / "custom_workflows"
+
+    def test_get_local_mcli_dir_returns_none_outside_git(self):
+        """Test that None is returned when not in a git repository."""
+        from mcli.lib.paths import get_local_mcli_dir
+
+        with patch("mcli.lib.paths.get_git_root", return_value=None):
+            result = get_local_mcli_dir()
+
+        assert result is None
+
+
+class TestResolveWorkspace:
+    """Test suite for resolve_workspace with dual fallback."""
+
+    def test_resolve_workspace_prefers_new_dir(self, tmp_path):
+        """Test that resolve_workspace prefers mcli/ over .mcli/."""
+        from mcli.lib.paths import resolve_workspace
+
+        (tmp_path / "mcli" / "workflows").mkdir(parents=True)
+        (tmp_path / ".mcli" / "workflows").mkdir(parents=True)
+
+        result = resolve_workspace(str(tmp_path))
+        assert result == tmp_path / "mcli" / "workflows"
+
+    def test_resolve_workspace_falls_back_to_legacy(self, tmp_path):
+        """Test that resolve_workspace falls back to .mcli/ when mcli/ missing."""
+        from mcli.lib.paths import resolve_workspace
+
+        (tmp_path / ".mcli" / "workflows").mkdir(parents=True)
+
+        result = resolve_workspace(str(tmp_path))
+        assert result == tmp_path / ".mcli" / "workflows"
+
+    def test_resolve_workspace_defaults_to_new(self, tmp_path):
+        """Test that resolve_workspace defaults to mcli/ for new dirs."""
+        from mcli.lib.paths import resolve_workspace
+
+        result = resolve_workspace(str(tmp_path))
+        assert result == tmp_path / "mcli" / "workflows"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/test_workflow_file_completion.py
+++ b/tests/unit/test_workflow_file_completion.py
@@ -186,9 +186,9 @@ class TestFilePathCompletion:
 
     def test_hidden_directories_shown(self, tmp_path):
         """Test that hidden directories are always shown."""
-        # Create hidden directory and file
-        (tmp_path / ".mcli").mkdir()
-        (tmp_path / ".mcli" / "workflows").mkdir()
+        # Create local mcli directory and file
+        (tmp_path / "mcli").mkdir()
+        (tmp_path / "mcli" / "workflows").mkdir()
         (tmp_path / ".hidden_file").write_text("test")
         (tmp_path / "visible.py").write_text("test")
 
@@ -206,8 +206,8 @@ class TestFilePathCompletion:
             completions = group.shell_complete(ctx, "./")
             completion_values = [c.value for c in completions]
 
-            # Hidden directory should be shown
-            assert any(".mcli/" in c for c in completion_values)
+            # mcli directory should be shown
+            assert any("mcli/" in c for c in completion_values)
 
             # Regular file should be shown
             assert any("visible.py" in c for c in completion_values)


### PR DESCRIPTION
## Summary

- Renames the local workspace directory from `.mcli/` to `mcli/` for visibility in IDEs, `ls`, and `git status`
- Global `~/.mcli` stays unchanged (Unix convention for hidden config dirs)
- Backward-compatible: legacy `.mcli/` still works with a deprecation warning
- `MCLI_LOCAL_DIR` env var allows custom local dir names
- `mcli self migrate --rename-dir` handles the rename for existing repos

## Changes

### Constants
- `DirNames.LOCAL_MCLI = "mcli"` — new local workspace dir
- `DirNames.LEGACY_LOCAL_MCLI = ".mcli"` — legacy fallback
- `EnvVars.MCLI_LOCAL_DIR` — env var override
- `WarningMessages.DEPRECATED_LOCAL_DIR` — deprecation message

### Path Resolution
- `get_local_mcli_dir()` — dual fallback: env → `mcli/` → `.mcli/` → default `mcli/`
- `resolve_workspace()` — checks both `mcli/` and `.mcli/` in workspace dirs
- `workspace_registry.py` — new `_resolve_local_workflows()` helper replaces 8 hardcoded strings

### Migration
- `mcli self migrate --rename-dir` — renames `.mcli/` to `mcli/` with dry-run support
- `mcli self migrate --status` — shows directory rename need

### Tests
- 19 new tests for local dir fallback and env override (`test_paths.py`)
- 7 new tests for `--rename-dir` functionality (`test_migrate_rename_dir.py`)
- Updated 4 test files for new default local dir name

## Test plan
- [x] `uv run pytest tests/unit/ -v` — 1287 passed (32 pre-existing async failures)
- [x] `uv run black --check --diff src/` — clean
- [x] `uv run isort --check-only src/` — clean
- [ ] CI/CD pipeline passes on GitHub

## Summary by Sourcery

Rename the default local workspace directory from hidden `.mcli/` to visible `mcli/` while maintaining backward compatibility and providing migration support.

New Features:
- Allow configuring the local workspace directory name via the MCLI_LOCAL_DIR environment variable.
- Add `mcli self migrate --rename-dir` to rename legacy `.mcli/` directories to `mcli/` with optional dry-run behavior.
- Expose new helpers in the workspace registry to resolve and detect local workflows in both new and legacy directory layouts.

Enhancements:
- Update path resolution and workspace discovery to prefer `mcli/` over `.mcli/` with fallback to the legacy layout and deprecation warning.
- Adjust init, env, and workflow-related commands to work with both the new `mcli/` directory and the legacy `.mcli/` structure.
- Extend migration status reporting to indicate when a directory rename from `.mcli/` to `mcli/` is required.
- Centralize local workflows path handling to reduce duplication and support dual-layout detection.

Build:
- Bump project version to 8.0.40 for the directory rename and migration feature.

Tests:
- Add unit tests covering local directory resolution precedence, env-var overrides, and behavior outside git repositories.
- Add unit tests for `resolve_workspace` handling of new and legacy directories.
- Add unit tests for `mcli self migrate --rename-dir`, including dry-run, edge cases, and status reporting.
- Update existing tests to reflect the new default `mcli/` local workspace directory and ensure completions and CLI flows still behave correctly.