### PR TITLE
refactor: neutral dual-dir support (mcli/ and .mcli/)

### DIFF
--- a/src/mcli/lib/constants/messages.py
+++ b/src/mcli/lib/constants/messages.py
@@ -59,10 +59,6 @@ class WarningMessages:
     RATE_LIMIT_WARNING = "Approaching rate limit for {service}"
     LARGE_FILE_WARNING = "Large file detected: {path} ({size})"
     AMBIGUOUS_COMMAND = "Multiple versions of '{name}' found. Specify language: {options}"
-    DEPRECATED_LOCAL_DIR = (
-        "[yellow]Using legacy '.mcli/' directory. "
-        "Run 'mcli self migrate --rename-dir' to upgrade to 'mcli/'.[/yellow]"
-    )
 
 
 class InfoMessages:

--- a/src/mcli/lib/constants/paths.py
+++ b/src/mcli/lib/constants/paths.py
@@ -8,9 +8,9 @@ Using these constants ensures consistency across the codebase.
 class DirNames:
     """Directory name constants."""
 
-    MCLI = ".mcli"  # Global home (~/.mcli) — UNCHANGED
-    LOCAL_MCLI = "mcli"  # New local workspace dir (visible in IDE/ls)
-    LEGACY_LOCAL_MCLI = ".mcli"  # Legacy local dir (for fallback)
+    MCLI = ".mcli"  # Global home (~/.mcli)
+    LOCAL_MCLI = "mcli"  # Preferred local workspace dir (visible in IDE/ls)
+    DOT_LOCAL_MCLI = ".mcli"  # Also supported as local workspace dir
     GIT = ".git"
     LOGS = "logs"
     CONFIG = "config"

--- a/src/mcli/lib/paths.py
+++ b/src/mcli/lib/paths.py
@@ -162,9 +162,12 @@ def get_local_mcli_dir() -> Optional[Path]:
 
     Resolution order:
     1. MCLI_LOCAL_DIR env var override
-    2. New 'mcli/' directory (visible in IDE/ls)
-    3. Legacy '.mcli/' directory (with deprecation warning)
-    4. Default to new 'mcli/' path (for fresh init)
+    2. 'mcli/' directory (preferred — visible in IDE/ls)
+    3. '.mcli/' directory (also supported)
+    4. Default to 'mcli/' path (for fresh init)
+
+    Both mcli/ and .mcli/ are fully supported. The -w flag on individual
+    commands always takes precedence over this resolution chain.
 
     Returns:
         Path to local mcli directory in git root, or None if not in a git repository
@@ -178,24 +181,17 @@ def get_local_mcli_dir() -> Optional[Path]:
     if custom_dir:
         return git_root / custom_dir
 
-    # 2. Check new "mcli/" directory
+    # 2. Prefer "mcli/" (visible in IDE/ls)
     new_dir = git_root / DirNames.LOCAL_MCLI
     if new_dir.exists():
         return new_dir
 
-    # 3. Fall back to legacy ".mcli/"
-    legacy_dir = git_root / DirNames.LEGACY_LOCAL_MCLI
+    # 3. Also support ".mcli/"
+    legacy_dir = git_root / DirNames.DOT_LOCAL_MCLI
     if legacy_dir.exists():
-        import warnings
-
-        warnings.warn(
-            "Using legacy '.mcli/' directory. " "Run 'mcli self migrate --rename-dir' to upgrade.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return legacy_dir
 
-    # 4. Neither exists — return new path (for fresh init)
+    # 4. Neither exists — default to mcli/ for fresh init
     return git_root / DirNames.LOCAL_MCLI
 
 
@@ -303,7 +299,7 @@ def resolve_workspace(workspace_path: str) -> Optional[Path]:
     # If it's a directory, look for mcli/workflows/ or .mcli/workflows/ inside it
     if path.is_dir():
         # Check new mcli/ first, then legacy .mcli/
-        for dir_name in [DirNames.LOCAL_MCLI, DirNames.LEGACY_LOCAL_MCLI]:
+        for dir_name in [DirNames.LOCAL_MCLI, DirNames.DOT_LOCAL_MCLI]:
             workflows_dir = path / dir_name / "workflows"
             if workflows_dir.exists():
                 return workflows_dir

--- a/src/mcli/lib/workspace_registry.py
+++ b/src/mcli/lib/workspace_registry.py
@@ -22,7 +22,7 @@ logger = get_logger(__name__)
 
 def _resolve_local_workflows(workspace_path: Path) -> Optional[Path]:
     """Find the workflows dir in a workspace, checking new and legacy paths."""
-    for dir_name in [DirNames.LOCAL_MCLI, DirNames.LEGACY_LOCAL_MCLI]:
+    for dir_name in [DirNames.LOCAL_MCLI, DirNames.DOT_LOCAL_MCLI]:
         workflows_dir = workspace_path / dir_name / "workflows"
         if workflows_dir.exists():
             return workflows_dir

--- a/src/mcli/self/env_cmd.py
+++ b/src/mcli/self/env_cmd.py
@@ -179,7 +179,7 @@ def env_command(
 
         # Check both new mcli/ and legacy .mcli/ local dir
         local_workflows = None
-        for dir_name in [DirNames.LOCAL_MCLI, DirNames.LEGACY_LOCAL_MCLI]:
+        for dir_name in [DirNames.LOCAL_MCLI, DirNames.DOT_LOCAL_MCLI]:
             candidate = workspace_dir / dir_name / "workflows"
             if candidate.exists():
                 local_workflows = candidate

--- a/src/mcli/self/migrate_cmd.py
+++ b/src/mcli/self/migrate_cmd.py
@@ -195,7 +195,7 @@ def get_migration_status() -> dict:
             local_new = git_root / DirNames.MCLI / "workflows"
 
             # Check if local dir needs rename (.mcli/ → mcli/)
-            legacy_local = git_root / DirNames.LEGACY_LOCAL_MCLI
+            legacy_local = git_root / DirNames.DOT_LOCAL_MCLI
             new_local = git_root / DirNames.LOCAL_MCLI
             needs_dir_rename = legacy_local.exists() and not new_local.exists()
 
@@ -496,10 +496,7 @@ def migrate_command(
                 console.print("  [green]✓ No migration needed[/green]")
 
             if local_status.get("needs_dir_rename"):
-                console.print(
-                    "  [yellow]⚠ Directory rename needed: "
-                    ".mcli/ → mcli/ (run --rename-dir)[/yellow]"
-                )
+                console.print("  [dim]Using .mcli/ — run --rename-dir to switch to mcli/[/dim]")
 
         # Show files to migrate if any
         all_files = global_status.get("files_to_migrate", [])
@@ -537,7 +534,7 @@ def migrate_command(
             error("Could not determine git root")
             return
 
-        old_dir = git_root / DirNames.LEGACY_LOCAL_MCLI  # .mcli
+        old_dir = git_root / DirNames.DOT_LOCAL_MCLI  # .mcli
         new_dir = git_root / DirNames.LOCAL_MCLI  # mcli
 
         if new_dir.exists() and not old_dir.exists():

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -218,10 +218,8 @@ class TestLocalMcliDir:
 
         assert result == tmp_path / "mcli"
 
-    def test_get_local_mcli_dir_falls_back_to_legacy(self, tmp_path):
+    def test_get_local_mcli_dir_falls_back_to_dotmcli(self, tmp_path):
         """Test that .mcli/ is used when mcli/ doesn't exist."""
-        import warnings
-
         from mcli.lib.paths import get_local_mcli_dir
 
         (tmp_path / ".git").mkdir()
@@ -230,13 +228,9 @@ class TestLocalMcliDir:
         with patch("mcli.lib.paths.get_git_root", return_value=tmp_path):
             with patch.dict(os.environ, {}, clear=False):
                 os.environ.pop("MCLI_LOCAL_DIR", None)
-                with warnings.catch_warnings(record=True) as w:
-                    warnings.simplefilter("always")
-                    result = get_local_mcli_dir()
+                result = get_local_mcli_dir()
 
-                    assert result == tmp_path / ".mcli"
-                    assert len(w) == 1
-                    assert "legacy" in str(w[0].message).lower()
+        assert result == tmp_path / ".mcli"
 
     def test_get_local_mcli_dir_defaults_to_new(self, tmp_path):
         """Test that mcli/ is returned for fresh repos with no existing dir."""


### PR DESCRIPTION
## Summary
- Remove deprecation warning from `.mcli/` fallback — both `mcli/` and `.mcli/` are equally valid local workspace directories
- Rename `LEGACY_LOCAL_MCLI` constant to `DOT_LOCAL_MCLI` to reflect neutral semantics
- Resolution chain: `MCLI_LOCAL_DIR` env → `mcli/` → `.mcli/` → default `mcli/`
- The `-w` flag on individual commands always takes precedence

## Test plan
- [x] All 1287 unit tests pass (32 pre-existing async failures unchanged)
- [x] `black --check` and `isort --check-only` pass
- [x] No deprecation warning emitted when `.mcli/` is used
- [x] `mcli/` still preferred over `.mcli/` when both exist

## Summary by Sourcery

Treat both mcli/ and .mcli/ as fully supported local workspace directories while keeping mcli/ as the preferred default.

Enhancements:
- Rename the legacy local workspace constant to DOT_LOCAL_MCLI and update all usages to reflect neutral support for .mcli/.
- Remove the deprecation warning and legacy messaging around using .mcli/ as a local workspace directory.
- Adjust migration status and messaging to describe .mcli/ usage as optional rather than requiring an upgrade.
- Clarify resolution order and workspace resolution helpers to check both mcli/ and .mcli/ consistently, with mcli/ preferred.

Tests:
- Update path resolution tests to assert .mcli/ fallback without expecting deprecation warnings.