### PR TITLE
fix: show correct git status in mcli init summary

### DIFF
--- a/src/mcli/app/init_cmd.py
+++ b/src/mcli/app/init_cmd.py
@@ -252,7 +252,12 @@ Thumbs.db
     if git_root:
         table.add_row("Git Repository", str(git_root))
     table.add_row("Lockfile", str(lockfile_path))
-    table.add_row("Git Initialized", "Yes" if git and (workflows_dir / ".git").exists() else "No")
+    table.add_row("Git Tracked", "Yes" if in_git_repo else "No")
+    if git:
+        table.add_row(
+            "Workflows Git",
+            "Yes" if (workflows_dir / ".git").exists() else "No",
+        )
 
     console.print(table)
     console.print()


### PR DESCRIPTION
## Summary
- The \"Git Initialized\" row in `mcli init` summary was misleading — it checked whether `--git` was passed, not whether the repo is git-tracked
- Replaced with **\"Git Tracked\"** that reflects the actual repo git status
- \"Workflows Git\" row only appears when `--git` flag is explicitly used

## Test plan
- [ ] Run `mcli init` in a git repo without `--git` flag — should show `Git Tracked: Yes`
- [ ] Run `mcli init` outside a git repo — should show `Git Tracked: No`
- [ ] Run `mcli init --git` — should show both `Git Tracked` and `Workflows Git` rows

## Summary by Sourcery

Update `mcli init` summary to report actual git tracking status and clarify when workflow-specific git information is shown.

Bug Fixes:
- Correct the git status row in `mcli init` summary to reflect whether the repository is git-tracked rather than whether the `--git` flag was used.

Enhancements:
- Show a separate `Workflows Git` row in `mcli init` summary only when the `--git` flag is explicitly provided.