### PR TITLE
fix(sync): IPNS-resolved pull also extracts scripts with --workflows-dir

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcli-framework"
-version = "8.0.47"
+version = "8.0.48"
 description = "Portable workflow framework - transform any script into a versioned, schedulable command. Store in ~/.mcli/workflows/, version with lockfile, run as daemon or cron job."
 readme = "README.md"
  requires-python = ">=3.10"

--- a/src/mcli/app/sync_cmd.py
+++ b/src/mcli/app/sync_cmd.py
@@ -495,20 +495,17 @@ def sync_pull_command(
 
     ipfs = IPFSSync()
 
-    if cid:
-        # Explicit CID — just retrieve it
-        info(SyncMessages.RETRIEVING_FROM_IPFS.format(cid=cid))
-        data = ipfs.pull(cid, verify=not no_verify)
-    else:
-        # No CID — resolve via IPNS
+    if not cid:
+        # No CID — resolve via IPNS, then fall through to the explicit-CID flow
+        # so that --workflows-dir extraction also works for IPNS-resolved pulls.
         if not ensure_daemon_running():
             error(SyncMessages.DAEMON_START_FAILED)
             return
 
         info(SyncMessages.IPNS_RESOLVING)
-        data = ipfs.pull_latest(scope="global", repo_name=repo)
+        cid = ipfs.resolve_latest_cid(scope="global", repo_name=repo)
 
-        if data is None:
+        if not cid:
             from mcli.lib.ipns_manager import get_sync_key
 
             if not get_sync_key():
@@ -519,6 +516,10 @@ def sync_pull_command(
                 error(SyncMessages.IPNS_RESOLVE_FAILED)
                 console.print(SyncMessages.IPNS_PULL_HINT)
             return
+
+    # Explicit or just-resolved CID — retrieve it
+    info(SyncMessages.RETRIEVING_FROM_IPFS.format(cid=cid))
+    data = ipfs.pull(cid, verify=not no_verify)
 
     if data:
         success(SyncMessages.RETRIEVED_FROM_IPFS)
@@ -543,7 +544,7 @@ def sync_pull_command(
             console.print(SyncMessages.VERSION_LABEL.format(version=data["version"]))
 
         # Optional: reconstruct script files from per-script CIDs
-        if workflows_dir and cid:
+        if workflows_dir:
             try:
                 written = ipfs.pull_workflows(cid, workflows_dir, verify=not no_verify)
             except ValueError as exc:

--- a/src/mcli/lib/ipfs_sync.py
+++ b/src/mcli/lib/ipfs_sync.py
@@ -541,6 +541,37 @@ class IPFSSync:
 
         return written
 
+    def resolve_latest_cid(
+        self,
+        scope: str = "global",
+        repo_name: Optional[str] = None,
+    ) -> Optional[str]:
+        """Resolve the deterministic IPNS name to a current CID.
+
+        Returns the CID string on success, ``None`` if the sync key is
+        unset, the key cannot be imported into Kubo, or IPNS resolution
+        fails. Surfaces the CID so CLI callers can hand it to
+        ``pull_workflows`` for script extraction.
+        """
+        sync_key = get_sync_key()
+        if not sync_key:
+            logger.warning("Sync key not configured — cannot resolve via IPNS")
+            return None
+
+        repo = repo_name or get_repo_name()
+        key_info = derive_key_info(sync_key, repo, scope)
+
+        ipns_name = ensure_key_imported(key_info)
+        if not ipns_name:
+            logger.error("Failed to import IPNS key into Kubo")
+            return None
+
+        cid = resolve_ipns(ipns_name)
+        if not cid:
+            logger.error("IPNS resolution failed — no workflows published yet?")
+            return None
+        return cid
+
     def pull_latest(
         self,
         scope: str = "global",
@@ -549,37 +580,12 @@ class IPFSSync:
     ) -> Optional[dict]:
         """Pull the latest workflow state by resolving via IPNS.
 
-        Requires MCLI_SYNC_KEY to be set. Uses deterministic IPNS key
-        derivation to find the latest CID without explicit CID sharing.
-
-        Args:
-            scope: Sync scope (e.g. "global" or "local")
-            repo_name: Override auto-detected repo name (for cross-repo pull)
-            verify: Whether to verify hash integrity
-
-        Returns:
-            Command data if successful, None otherwise
+        Requires the sync key to be configured (env var or store).
+        Returns the command data dict on success, ``None`` otherwise.
         """
-        sync_key = get_sync_key()
-        if not sync_key:
-            logger.warning("MCLI_SYNC_KEY not set — cannot resolve via IPNS")
-            return None
-
-        repo = repo_name or get_repo_name()
-        key_info = derive_key_info(sync_key, repo, scope)
-
-        # Ensure key is in Kubo so we can resolve
-        ipns_name = ensure_key_imported(key_info)
-        if not ipns_name:
-            logger.error("Failed to import IPNS key into Kubo")
-            return None
-
-        # Resolve IPNS to CID
-        cid = resolve_ipns(ipns_name)
+        cid = self.resolve_latest_cid(scope=scope, repo_name=repo_name)
         if not cid:
-            logger.error("IPNS resolution failed — no workflows published yet?")
             return None
-
         return self.pull(cid, verify=verify)
 
     def get_history(self, limit: int = 10) -> list[dict]:

--- a/tests/unit/test_ipns_resolve_latest_cid.py
+++ b/tests/unit/test_ipns_resolve_latest_cid.py
@@ -1,0 +1,78 @@
+"""Unit tests for IPFSSync.resolve_latest_cid().
+
+Adds a thin helper used by the CLI so that ``mcli sync pull`` (no CID)
+can capture the resolved CID and fall through to the same explicit-CID
+flow that handles ``-w / --workflows-dir`` script extraction.
+
+Without this, the CLI's pre-existing IPNS-auto-resolve path wraps the
+CID inside ``pull_latest()`` and never surfaces it, so the extraction
+guard ``if workflows_dir and cid`` always falls through.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestResolveLatestCid:
+    def test_returns_cid_when_sync_key_present(self):
+        from mcli.lib.ipfs_sync import IPFSSync
+
+        sync = IPFSSync()
+        with (
+            patch("mcli.lib.ipfs_sync.get_sync_key", return_value="my-secret"),
+            patch("mcli.lib.ipfs_sync.get_repo_name", return_value="my-repo"),
+            patch("mcli.lib.ipfs_sync.derive_key_info") as mock_derive,
+            patch("mcli.lib.ipfs_sync.ensure_key_imported", return_value="12D3KooW..."),
+            patch("mcli.lib.ipfs_sync.resolve_ipns", return_value="QmResolved"),
+        ):
+            mock_derive.return_value = MagicMock(key_name="mcli-abc")
+            assert sync.resolve_latest_cid(scope="global") == "QmResolved"
+
+    def test_returns_none_when_sync_key_missing(self):
+        from mcli.lib.ipfs_sync import IPFSSync
+
+        sync = IPFSSync()
+        with patch("mcli.lib.ipfs_sync.get_sync_key", return_value=None):
+            assert sync.resolve_latest_cid() is None
+
+    def test_returns_none_when_key_import_fails(self):
+        from mcli.lib.ipfs_sync import IPFSSync
+
+        sync = IPFSSync()
+        with (
+            patch("mcli.lib.ipfs_sync.get_sync_key", return_value="my-secret"),
+            patch("mcli.lib.ipfs_sync.get_repo_name", return_value="my-repo"),
+            patch("mcli.lib.ipfs_sync.derive_key_info") as mock_derive,
+            patch("mcli.lib.ipfs_sync.ensure_key_imported", return_value=None),
+        ):
+            mock_derive.return_value = MagicMock(key_name="mcli-abc")
+            assert sync.resolve_latest_cid() is None
+
+    def test_returns_none_when_ipns_resolve_fails(self):
+        from mcli.lib.ipfs_sync import IPFSSync
+
+        sync = IPFSSync()
+        with (
+            patch("mcli.lib.ipfs_sync.get_sync_key", return_value="my-secret"),
+            patch("mcli.lib.ipfs_sync.get_repo_name", return_value="my-repo"),
+            patch("mcli.lib.ipfs_sync.derive_key_info") as mock_derive,
+            patch("mcli.lib.ipfs_sync.ensure_key_imported", return_value="12D3KooW..."),
+            patch("mcli.lib.ipfs_sync.resolve_ipns", return_value=None),
+        ):
+            mock_derive.return_value = MagicMock(key_name="mcli-abc")
+            assert sync.resolve_latest_cid() is None
+
+    def test_uses_repo_override(self):
+        from mcli.lib.ipfs_sync import IPFSSync
+
+        sync = IPFSSync()
+        with (
+            patch("mcli.lib.ipfs_sync.get_sync_key", return_value="my-secret"),
+            patch("mcli.lib.ipfs_sync.get_repo_name") as mock_repo,
+            patch("mcli.lib.ipfs_sync.derive_key_info") as mock_derive,
+            patch("mcli.lib.ipfs_sync.ensure_key_imported", return_value="12D3KooW"),
+            patch("mcli.lib.ipfs_sync.resolve_ipns", return_value="QmX"),
+        ):
+            mock_derive.return_value = MagicMock(key_name="mcli-abc")
+            sync.resolve_latest_cid(scope="global", repo_name="other")
+            mock_repo.assert_not_called()
+            mock_derive.assert_called_once_with("my-secret", "other", "global")


### PR DESCRIPTION
## Summary
- New thin helper `IPFSSync.resolve_latest_cid()` returns the IPNS-derived CID; `pull_latest()` is now built on it.
- CLI refactored: when no CID is passed, resolve IPNS upfront, then fall into the same explicit-CID flow that handles `--workflows-dir` script extraction.

## Why
Bug found while testing the new `mcli sync key` workflow on a simulated second host: `mcli sync pull -w .mcli/workflows -o .mcli/workflows/commands.lock.json` (no CID) wrote the lockfile but skipped script bodies. Workaround was to pass an explicit CID. After this fix the zero-CID command works end-to-end.

## Test plan
- [x] 5 new unit tests in `tests/unit/test_ipns_resolve_latest_cid.py`
- [x] 48 sync-related tests pass (across 5 modules)
- [ ] End-to-end on TODO_TEST: post-merge reinstall → wipe scripts → zero-CID pull → run command

## Notes
- Pre-existing broken `Test Python Package` workflow + `submit-pypi` 5xx will likely red the PR. Same pattern as #194 / #195. Merging with admin override.
- Version bumped to 8.0.48.

## Summary by Sourcery

Ensure IPNS-based workflow pulls use the same CID-based flow as explicit pulls so script extraction works consistently.

New Features:
- Expose a new IPFSSync.resolve_latest_cid helper to surface the IPNS-resolved CID for callers.

Bug Fixes:
- Fix sync pull without an explicit CID so that workflows are correctly reconstructed when using --workflows-dir.

Enhancements:
- Refactor sync pull CLI logic to share a single CID-based retrieval path for both explicit and IPNS-resolved pulls.

Tests:
- Add unit tests for IPFSSync.resolve_latest_cid covering success, missing sync key, key import failure, IPNS resolution failure, and repo override behavior.

Chores:
- Bump framework version to 8.0.48.