### PR TITLE
feat(ci): mcli ci — act-first CI for private repos

### DIFF
--- a/docs/commands/ci.md
+++ b/docs/commands/ci.md
@@ -1,0 +1,60 @@
+# `mcli ci` — act-first CI
+
+Make local [`act`](https://github.com/nektos/act) the primary pull-request gate and
+stop billed GitHub-hosted Actions minutes on private repositories. Hosted workflows
+are kept (still runnable via `workflow_dispatch`) but no longer auto-fire on
+`push`/`pull_request`; a dormant self-hosted fallback workflow is added that activates
+only where a self-hosted runner is online.
+
+## Commands
+
+| Command | What it does |
+|---------|--------------|
+| `mcli ci migrate [--dry-run]` | Strip `push`/`pull_request` triggers from this repo's GitHub-hosted workflows and add a `self-hosted-ci.yml` fallback. Idempotent. `--dry-run` shows the plan without writing. |
+| `mcli ci preflight [--event EVENT]` | Run `act` as the PR gate. See exit codes below. |
+| `mcli ci pr` | Run `preflight`; on pass, `gh pr create --fill --base main`. On the runner-fallback path, push and open the PR. |
+| `mcli ci doctor` | Report `act` / Docker / online-runner status for the current repo. |
+| `mcli ci install-hook` | Install an opt-in `.git/hooks/pre-push` that runs `mcli ci preflight`. |
+
+## `preflight` exit-code contract
+
+| Exit | Meaning |
+|------|---------|
+| `0` | `act` ran and passed — OK to open the PR. |
+| `1` | `act` ran and a job failed — fix before opening the PR. |
+| `2` | `act` could not run here (no Docker / no `act` / image pull failed) **and** no online self-hosted runner exists — cannot validate. |
+| `3` | `act` could not run here, but an online self-hosted runner exists — push and let the runner validate. |
+
+"Could not run" is distinguished from "ran and failed" by a capability probe
+(Docker daemon up + `act -l` succeeds) before any job is executed.
+
+## How the gate works
+
+```
+git push  (or: mcli ci pr)
+   └─ mcli ci preflight
+        ├─ act passed ............................ open PR              ($0)
+        ├─ act failed ............................ blocked, fix it
+        └─ act unreachable
+             ├─ repo has an online runner ........ push; runner validates
+             └─ no runner ........................ cannot validate
+```
+
+## Secrets for `act`
+
+If a `.secrets` file exists in the repo root, `preflight` passes it to `act`
+(`--secret-file .secrets`). Keep `.secrets` out of git (add it to `.gitignore`);
+populate it from your secrets manager.
+
+## Migration notes
+
+- Migration is idempotent: a marker comment (`# mcli-ci: hosted-triggers-stripped`)
+  makes re-runs no-ops.
+- `on:` is workflow-level. A workflow that mixes hosted and self-hosted jobs loses
+  the self-hosted job's auto-trigger too; the separate `self-hosted-ci.yml` covers
+  the runner path when a runner exists.
+- The fallback `self-hosted-ci.yml` gets a `pull_request` trigger only if the repo
+  already has an online self-hosted runner at migrate time; otherwise it is
+  `workflow_dispatch`-only (dormant) until you register one.
+- Re-enabling hosted CI: the original workflows still exist — run them manually via
+  `workflow_dispatch`, or restore the stripped triggers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
 dependencies = [
   # Core CLI dependencies
   "click>=8.1.7,<9.0.0",
+  "ruamel.yaml>=0.18,<0.19",
   "rich>=14.0.0,<15.0.0",
   "requests>=2.31.0,<3.0.0",
   "tomli>=2.2.1,<3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcli-framework"
-version = "8.0.48"
+version = "8.0.49"
 description = "Portable workflow framework - transform any script into a versioned, schedulable command. Store in ~/.mcli/workflows/, version with lockfile, run as daemon or cron job."
 readme = "README.md"
  requires-python = ">=3.10"

--- a/src/mcli/app/main.py
+++ b/src/mcli/app/main.py
@@ -447,6 +447,15 @@ def _add_lazy_commands(app: click.Group):
     except ImportError as e:
         logger.debug(f"Could not load sync group: {e}")
 
+    # mcli ci - act-first CI gate + hosted-trigger migration
+    try:
+        from mcli.workflow.ci.ci import ci
+
+        app.add_command(ci, name="ci")
+        logger.debug("Added ci group")
+    except ImportError as e:
+        logger.debug(f"Could not load ci group: {e}")
+
     # mcli setup - Onboarding wizard for new users
     try:
         from mcli.app.setup_cmd import setup

--- a/src/mcli/workflow/ci/__init__.py
+++ b/src/mcli/workflow/ci/__init__.py
@@ -1,0 +1,1 @@
+"""act-first CI tooling: local act gate + hosted-trigger stripping for private repos."""

--- a/src/mcli/workflow/ci/act_runner.py
+++ b/src/mcli/workflow/ci/act_runner.py
@@ -1,4 +1,5 @@
 """Run `act` locally and classify the outcome for the PR gate."""
+
 from __future__ import annotations
 
 import shutil

--- a/src/mcli/workflow/ci/act_runner.py
+++ b/src/mcli/workflow/ci/act_runner.py
@@ -1,0 +1,49 @@
+"""Run `act` locally and classify the outcome for the PR gate."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from enum import Enum
+from pathlib import Path
+
+
+class PreflightResult(Enum):
+    PASS = "pass"
+    FAIL = "fail"
+    UNREACHABLE = "unreachable"
+
+
+def act_available() -> bool:
+    return shutil.which("act") is not None
+
+
+def docker_running() -> bool:
+    try:
+        proc = subprocess.run(["docker", "info"], capture_output=True, timeout=30)
+        return proc.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def probe() -> bool:
+    """Can act actually run here? Needs the binary, a live docker daemon, and `act -l`."""
+    if not act_available() or not docker_running():
+        return False
+    try:
+        proc = subprocess.run(["act", "-l"], capture_output=True, text=True, timeout=60)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    return proc.returncode == 0
+
+
+def build_act_command(event: str) -> list[str]:
+    cmd = ["act", event]
+    if Path(".secrets").exists():
+        cmd += ["--secret-file", ".secrets"]
+    return cmd
+
+
+def run_act(event: str = "pull_request") -> PreflightResult:
+    """Run act for `event`. PASS on exit 0, else FAIL. (Probe gates UNREACHABLE upstream.)"""
+    proc = subprocess.run(build_act_command(event))
+    return PreflightResult.PASS if proc.returncode == 0 else PreflightResult.FAIL

--- a/src/mcli/workflow/ci/act_runner.py
+++ b/src/mcli/workflow/ci/act_runner.py
@@ -47,3 +47,14 @@ def run_act(event: str = "pull_request") -> PreflightResult:
     """Run act for `event`. PASS on exit 0, else FAIL. (Probe gates UNREACHABLE upstream.)"""
     proc = subprocess.run(build_act_command(event))
     return PreflightResult.PASS if proc.returncode == 0 else PreflightResult.FAIL
+
+
+def preflight(repo_slug: str, event: str = "pull_request") -> PreflightResult:
+    """Primary gate. PASS/FAIL if act can run; UNREACHABLE if act can't start here.
+
+    `repo_slug` is accepted for symmetry and future use; the runner fallback is
+    orchestrated by the CLI layer based on runner_status.has_online_runner.
+    """
+    if not probe():
+        return PreflightResult.UNREACHABLE
+    return run_act(event)

--- a/src/mcli/workflow/ci/ci.py
+++ b/src/mcli/workflow/ci/ci.py
@@ -1,4 +1,5 @@
 """`mcli ci` — act-first CI gate and hosted-trigger migration for private repos."""
+
 from __future__ import annotations
 
 import re
@@ -8,15 +9,10 @@ from pathlib import Path
 
 import click
 
-from mcli.workflow.ci.workflow_transform import transform_file, write_self_hosted_workflow
+from mcli.workflow.ci.act_runner import PreflightResult, act_available, docker_running
+from mcli.workflow.ci.act_runner import preflight as preflight_fn
 from mcli.workflow.ci.runner_status import has_online_runner
-from mcli.workflow.ci.act_runner import (
-    PreflightResult,
-    act_available,
-    docker_running,
-    preflight as preflight_fn,
-)
-
+from mcli.workflow.ci.workflow_transform import transform_file, write_self_hosted_workflow
 
 _GITHUB_REMOTE_RE = re.compile(
     r"(?:git@github\.com:|https://github\.com/)([^/]+/[^/]+?)(?:\.git)?/?$"
@@ -28,7 +24,9 @@ def current_repo_slug() -> str | None:
     try:
         url = subprocess.run(
             ["git", "remote", "get-url", "origin"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True,
+            text=True,
+            timeout=10,
         ).stdout.strip()
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return None
@@ -77,7 +75,8 @@ def migrate(dry_run):
 
     files = sorted(p for p in wfdir.glob("*.y*ml") if p.name != "self-hosted-ci.yml")
     if dry_run:
-        from mcli.workflow.ci.workflow_transform import workflow_has_hosted_job, MARKER, _yaml
+        from mcli.workflow.ci.workflow_transform import MARKER, _yaml, workflow_has_hosted_job
+
         for f in files:
             text = f.read_text()
             if MARKER in text:
@@ -98,8 +97,7 @@ def migrate(dry_run):
 
 
 @ci.command()
-@click.option("--event", default="pull_request", show_default=True,
-              help="act event to simulate.")
+@click.option("--event", default="pull_request", show_default=True, help="act event to simulate.")
 def preflight(event):
     """Run act as the PR gate. Exit 0=pass, 1=fail, 2=cannot validate, 3=use runner."""
     slug = current_repo_slug()
@@ -112,8 +110,10 @@ def preflight(event):
         raise SystemExit(1)
     # UNREACHABLE
     if slug and has_online_runner(slug):
-        click.echo("⚠️  act unreachable here; an online runner exists — "
-                   "push and let the self-hosted runner validate.")
+        click.echo(
+            "⚠️  act unreachable here; an online runner exists — "
+            "push and let the self-hosted runner validate."
+        )
         raise SystemExit(3)
     click.echo("⚠️  act unreachable and no online runner — cannot validate this PR.")
     raise SystemExit(2)

--- a/src/mcli/workflow/ci/ci.py
+++ b/src/mcli/workflow/ci/ci.py
@@ -1,0 +1,85 @@
+"""`mcli ci` — act-first CI gate and hosted-trigger migration for private repos."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import click
+
+from mcli.workflow.ci.workflow_transform import transform_file, write_self_hosted_workflow
+from mcli.workflow.ci.runner_status import has_online_runner
+from mcli.workflow.ci.act_runner import PreflightResult, preflight
+
+
+def current_repo_slug() -> str | None:
+    """owner/name from the origin remote, or None."""
+    try:
+        url = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=10,
+        ).stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if not url:
+        return None
+    url = url.removesuffix(".git")
+    url = url.replace("git@github.com:", "").replace("https://github.com/", "")
+    return url or None
+
+
+def detect_test_command() -> str:
+    """Best-effort test command for the self-hosted fallback workflow."""
+    if Path("Makefile").exists():
+        txt = Path("Makefile").read_text()
+        if "\ntest:" in txt or txt.startswith("test:"):
+            return "make test"
+    if Path("pyproject.toml").exists() or Path("pytest.ini").exists():
+        return "uv run pytest -v || pytest -v"
+    if Path("package.json").exists():
+        return "npm test"
+    if Path("mix.exs").exists():
+        return "mix test"
+    return "echo 'TODO: set test command' && exit 1"
+
+
+def workflows_dir() -> Path:
+    return Path(".github") / "workflows"
+
+
+@click.group()
+def ci():
+    """act-first CI: local act gate + stop billed hosted runners on private repos."""
+
+
+@ci.command()
+@click.option("--dry-run", is_flag=True, help="Show what would change without writing.")
+def migrate(dry_run):
+    """Strip hosted triggers from this repo's workflows + add self-hosted fallback."""
+    wfdir = workflows_dir()
+    if not wfdir.exists():
+        click.echo("No .github/workflows directory; nothing to migrate.")
+        return
+    slug = current_repo_slug()
+    has_runner = has_online_runner(slug) if slug else False
+    test_cmd = detect_test_command()
+
+    files = sorted(p for p in wfdir.glob("*.y*ml") if p.name != "self-hosted-ci.yml")
+    if dry_run:
+        from mcli.workflow.ci.workflow_transform import workflow_has_hosted_job, MARKER, _yaml
+        for f in files:
+            text = f.read_text()
+            if MARKER in text:
+                click.echo(f"  skip (already migrated): {f.name}")
+                continue
+            hosted = workflow_has_hosted_job(_yaml().load(text))
+            click.echo(f"  {'STRIP' if hosted else 'keep '}: {f.name}")
+        click.echo(f"  fallback self-hosted-ci.yml (pull_request={has_runner}, test='{test_cmd}')")
+        return
+
+    changed = [f.name for f in files if transform_file(f)]
+    created = write_self_hosted_workflow(wfdir, test_cmd, with_pull_request=has_runner)
+    for name in changed:
+        click.echo(f"  stripped: {name}")
+    if created:
+        click.echo(f"  created: self-hosted-ci.yml (pull_request={has_runner})")
+    click.echo(f"Done. {len(changed)} workflow(s) migrated.")

--- a/src/mcli/workflow/ci/ci.py
+++ b/src/mcli/workflow/ci/ci.py
@@ -8,7 +8,7 @@ import click
 
 from mcli.workflow.ci.workflow_transform import transform_file, write_self_hosted_workflow
 from mcli.workflow.ci.runner_status import has_online_runner
-from mcli.workflow.ci.act_runner import PreflightResult, preflight
+from mcli.workflow.ci.act_runner import PreflightResult, preflight as preflight_fn
 
 
 def current_repo_slug() -> str | None:
@@ -83,3 +83,45 @@ def migrate(dry_run):
     if created:
         click.echo(f"  created: self-hosted-ci.yml (pull_request={has_runner})")
     click.echo(f"Done. {len(changed)} workflow(s) migrated.")
+
+
+@ci.command()
+@click.option("--event", default="pull_request", show_default=True,
+              help="act event to simulate.")
+def preflight(event):
+    """Run act as the PR gate. Exit 0=pass, 1=fail, 2=cannot validate, 3=use runner."""
+    slug = current_repo_slug()
+    result = preflight_fn(slug, event)
+    if result == PreflightResult.PASS:
+        click.echo("✅ act passed — OK to open PR.")
+        raise SystemExit(0)
+    if result == PreflightResult.FAIL:
+        click.echo("❌ act failed — fix before opening PR.")
+        raise SystemExit(1)
+    # UNREACHABLE
+    if slug and has_online_runner(slug):
+        click.echo("⚠️  act unreachable here; an online runner exists — "
+                   "push and let the self-hosted runner validate.")
+        raise SystemExit(3)
+    click.echo("⚠️  act unreachable and no online runner — cannot validate this PR.")
+    raise SystemExit(2)
+
+
+@ci.command()
+def pr():
+    """preflight, then `gh pr create --fill --base main` if it passed."""
+    slug = current_repo_slug()
+    result = preflight_fn(slug)
+    if result == PreflightResult.PASS:
+        subprocess.run(["gh", "pr", "create", "--fill", "--base", "main"], check=False)
+        return
+    if result == PreflightResult.FAIL:
+        click.echo("act failed; not opening PR.")
+        raise SystemExit(1)
+    if slug and has_online_runner(slug):
+        click.echo("act unreachable; pushing so the runner can validate.")
+        subprocess.run(["git", "push", "-u", "origin", "HEAD"], check=False)
+        subprocess.run(["gh", "pr", "create", "--fill", "--base", "main"], check=False)
+        return
+    click.echo("act unreachable and no runner; refusing to open an unvalidated PR.")
+    raise SystemExit(2)

--- a/src/mcli/workflow/ci/ci.py
+++ b/src/mcli/workflow/ci/ci.py
@@ -1,6 +1,7 @@
 """`mcli ci` — act-first CI gate and hosted-trigger migration for private repos."""
 from __future__ import annotations
 
+import stat
 import subprocess
 from pathlib import Path
 
@@ -8,7 +9,12 @@ import click
 
 from mcli.workflow.ci.workflow_transform import transform_file, write_self_hosted_workflow
 from mcli.workflow.ci.runner_status import has_online_runner
-from mcli.workflow.ci.act_runner import PreflightResult, preflight as preflight_fn
+from mcli.workflow.ci.act_runner import (
+    PreflightResult,
+    act_available,
+    docker_running,
+    preflight as preflight_fn,
+)
 
 
 def current_repo_slug() -> str | None:
@@ -125,3 +131,34 @@ def pr():
         return
     click.echo("act unreachable and no runner; refusing to open an unvalidated PR.")
     raise SystemExit(2)
+
+
+PRE_PUSH_HOOK = """#!/usr/bin/env bash
+# mcli-ci pre-push gate: validate with act before pushing.
+exec mcli ci preflight
+"""
+
+
+@ci.command()
+def doctor():
+    """Show act/docker/runner status for this repo."""
+    click.echo(f"act installed:  {act_available()}")
+    click.echo(f"docker running: {docker_running()}")
+    slug = current_repo_slug()
+    click.echo(f"repo:           {slug or '(no origin)'}")
+    if slug:
+        click.echo(f"online runner:  {has_online_runner(slug)}")
+
+
+@ci.command(name="install-hook")
+def install_hook():
+    """Install an opt-in pre-push hook that runs `mcli ci preflight`."""
+    hooks = Path(".git") / "hooks"
+    if not hooks.exists():
+        click.echo("Not a git repo (.git/hooks missing).")
+        raise SystemExit(1)
+    hook = hooks / "pre-push"
+    hook.write_text(PRE_PUSH_HOOK)
+    mode = hook.stat().st_mode
+    hook.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    click.echo(f"Installed pre-push hook at {hook}")

--- a/src/mcli/workflow/ci/ci.py
+++ b/src/mcli/workflow/ci/ci.py
@@ -1,6 +1,7 @@
 """`mcli ci` — act-first CI gate and hosted-trigger migration for private repos."""
 from __future__ import annotations
 
+import re
 import stat
 import subprocess
 from pathlib import Path
@@ -17,8 +18,13 @@ from mcli.workflow.ci.act_runner import (
 )
 
 
+_GITHUB_REMOTE_RE = re.compile(
+    r"(?:git@github\.com:|https://github\.com/)([^/]+/[^/]+?)(?:\.git)?/?$"
+)
+
+
 def current_repo_slug() -> str | None:
-    """owner/name from the origin remote, or None."""
+    """owner/name from a github.com origin remote, or None (non-GitHub or no remote)."""
     try:
         url = subprocess.run(
             ["git", "remote", "get-url", "origin"],
@@ -28,15 +34,15 @@ def current_repo_slug() -> str | None:
         return None
     if not url:
         return None
-    url = url.removesuffix(".git")
-    url = url.replace("git@github.com:", "").replace("https://github.com/", "")
-    return url or None
+    match = _GITHUB_REMOTE_RE.match(url)
+    return match.group(1) if match else None
 
 
 def detect_test_command() -> str:
     """Best-effort test command for the self-hosted fallback workflow."""
-    if Path("Makefile").exists():
-        txt = Path("Makefile").read_text()
+    makefile = Path("Makefile")
+    if makefile.exists():
+        txt = makefile.read_text()
         if "\ntest:" in txt or txt.startswith("test:"):
             return "make test"
     if Path("pyproject.toml").exists() or Path("pytest.ini").exists():
@@ -119,6 +125,8 @@ def pr():
     slug = current_repo_slug()
     result = preflight_fn(slug)
     if result == PreflightResult.PASS:
+        # check=False on purpose: let gh/git stream their own errors to the terminal
+        # rather than raising CalledProcessError and hiding their output.
         subprocess.run(["gh", "pr", "create", "--fill", "--base", "main"], check=False)
         return
     if result == PreflightResult.FAIL:

--- a/src/mcli/workflow/ci/runner_status.py
+++ b/src/mcli/workflow/ci/runner_status.py
@@ -1,4 +1,5 @@
 """Query GitHub for self-hosted runner availability via the gh CLI."""
+
 from __future__ import annotations
 
 import json
@@ -10,7 +11,9 @@ def has_online_runner(repo_slug: str) -> bool:
     try:
         proc = subprocess.run(
             ["gh", "api", f"repos/{repo_slug}/actions/runners"],
-            capture_output=True, text=True, timeout=30,
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return False

--- a/src/mcli/workflow/ci/runner_status.py
+++ b/src/mcli/workflow/ci/runner_status.py
@@ -1,0 +1,23 @@
+"""Query GitHub for self-hosted runner availability via the gh CLI."""
+from __future__ import annotations
+
+import json
+import subprocess
+
+
+def has_online_runner(repo_slug: str) -> bool:
+    """True if `repo_slug` (owner/name) has at least one online self-hosted runner."""
+    try:
+        proc = subprocess.run(
+            ["gh", "api", f"repos/{repo_slug}/actions/runners"],
+            capture_output=True, text=True, timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    if proc.returncode != 0:
+        return False
+    try:
+        data = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError:
+        return False
+    return any(r.get("status") == "online" for r in data.get("runners", []))

--- a/src/mcli/workflow/ci/workflow_transform.py
+++ b/src/mcli/workflow/ci/workflow_transform.py
@@ -72,11 +72,12 @@ def strip_hosted_triggers(doc) -> bool:
             on["workflow_dispatch"] = None
             changed = True
     elif isinstance(on, list):
-        kept = [x for x in on if x not in ("push", "pull_request")]
-        if "workflow_dispatch" not in kept:
-            kept.append("workflow_dispatch")
-        if kept != list(on):
-            doc["on"] = kept
+        for key in ("push", "pull_request"):
+            while key in on:
+                on.remove(key)
+                changed = True
+        if "workflow_dispatch" not in on:
+            on.append("workflow_dispatch")
             changed = True
     elif isinstance(on, str):
         if on in ("push", "pull_request"):
@@ -95,6 +96,10 @@ def transform_file(path: Path) -> bool:
     doc = yaml.load(text)
     if not workflow_has_hosted_job(doc):
         return False
+    # `on:` is workflow-level. If a workflow mixes hosted and self-hosted jobs,
+    # stripping push/pull_request also removes the self-hosted job's auto-trigger.
+    # Acceptable here: the separate self-hosted-ci.yml provides the runner PR path
+    # when a runner exists. Re-add triggers by hand if a single workflow needs both.
     strip_hosted_triggers(doc)
     doc.yaml_set_start_comment(f"{MARKER}\n")
     buf = StringIO()

--- a/src/mcli/workflow/ci/workflow_transform.py
+++ b/src/mcli/workflow/ci/workflow_transform.py
@@ -1,0 +1,33 @@
+"""Transform GitHub Actions workflows for act-first CI on private repos."""
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+MARKER = "mcli-ci: hosted-triggers-stripped"
+SELF_HOSTED_FILENAME = "self-hosted-ci.yml"
+HOSTED_PREFIXES = ("ubuntu", "macos", "windows")
+
+
+def is_hosted_label(label: str) -> bool:
+    """True if a runs-on label names a GitHub-hosted runner image."""
+    return str(label).lower().startswith(HOSTED_PREFIXES)
+
+
+def runs_on_is_hosted(runs_on) -> bool:
+    """Classify a job's runs-on. Conservative: unknown expressions count as hosted."""
+    if runs_on is None:
+        return False
+    if isinstance(runs_on, (list, tuple)):
+        labels = [str(x) for x in runs_on]
+        if any("self-hosted" in lbl for lbl in labels):
+            return False
+        return any(is_hosted_label(lbl) for lbl in labels)
+    text = str(runs_on)
+    if "self-hosted" in text:
+        return False
+    if "${{" in text:
+        return True  # unknown matrix/expression -> assume hosted to stop cost
+    return is_hosted_label(text)

--- a/src/mcli/workflow/ci/workflow_transform.py
+++ b/src/mcli/workflow/ci/workflow_transform.py
@@ -102,6 +102,10 @@ def transform_file(path: Path) -> bool:
     # when a runner exists. Re-add triggers by hand if a single workflow needs both.
     strip_hosted_triggers(doc)
     doc.yaml_set_start_comment(f"{MARKER}\n")
+    # Pinning version=(1,2) at load keeps `on` a string key (not YAML 1.1 bool True).
+    # Reset it before dumping so ruamel does not prepend a `%YAML 1.2` / `---` directive
+    # to the workflow file (the key is already a plain string in the loaded document).
+    yaml.version = None
     buf = StringIO()
     yaml.dump(doc, buf)
     path.write_text(buf.getvalue())

--- a/src/mcli/workflow/ci/workflow_transform.py
+++ b/src/mcli/workflow/ci/workflow_transform.py
@@ -1,4 +1,5 @@
 """Transform GitHub Actions workflows for act-first CI on private repos."""
+
 from __future__ import annotations
 
 from io import StringIO
@@ -39,9 +40,9 @@ def runs_on_is_hosted(runs_on) -> bool:
 # round-tripping. Round-trip preservation is a hard requirement of this transform.
 def _yaml() -> YAML:
     y = YAML()
-    y.version = (1, 2)        # critical: keeps bare `on:` a string, not boolean True
+    y.version = (1, 2)  # critical: keeps bare `on:` a string, not boolean True
     y.preserve_quotes = True
-    y.width = 4096            # avoid reflowing long lines
+    y.width = 4096  # avoid reflowing long lines
     y.indent(mapping=2, sequence=4, offset=2)
     return y
 
@@ -137,8 +138,9 @@ def render_self_hosted_workflow(test_command: str, with_pull_request: bool) -> s
     )
 
 
-def write_self_hosted_workflow(workflows_dir: Path, test_command: str,
-                               with_pull_request: bool) -> bool:
+def write_self_hosted_workflow(
+    workflows_dir: Path, test_command: str, with_pull_request: bool
+) -> bool:
     """Write self-hosted-ci.yml if absent. Returns True if created."""
     workflows_dir = Path(workflows_dir)
     target = workflows_dir / SELF_HOSTED_FILENAME

--- a/src/mcli/workflow/ci/workflow_transform.py
+++ b/src/mcli/workflow/ci/workflow_transform.py
@@ -101,3 +101,40 @@ def transform_file(path: Path) -> bool:
     yaml.dump(doc, buf)
     path.write_text(buf.getvalue())
     return True
+
+
+def render_self_hosted_workflow(test_command: str, with_pull_request: bool) -> str:
+    """Render the dormant self-hosted fallback workflow as YAML text."""
+    triggers = "  workflow_dispatch:\n"
+    if with_pull_request:
+        triggers += "  pull_request:\n"
+    ref = "${{ github.ref }}"
+    return (
+        f"# {MARKER}\n"
+        "name: self-hosted-ci\n"
+        "on:\n"
+        f"{triggers}"
+        "concurrency:\n"
+        f"  group: self-hosted-ci-{ref}\n"
+        "  cancel-in-progress: true\n"
+        "jobs:\n"
+        "  test:\n"
+        "    runs-on: [self-hosted, Linux, X64]\n"
+        "    timeout-minutes: 30\n"
+        "    steps:\n"
+        "      - uses: actions/checkout@v4\n"
+        "      - name: Run tests\n"
+        f"        run: {test_command}\n"
+    )
+
+
+def write_self_hosted_workflow(workflows_dir: Path, test_command: str,
+                               with_pull_request: bool) -> bool:
+    """Write self-hosted-ci.yml if absent. Returns True if created."""
+    workflows_dir = Path(workflows_dir)
+    target = workflows_dir / SELF_HOSTED_FILENAME
+    if target.exists():
+        return False
+    workflows_dir.mkdir(parents=True, exist_ok=True)
+    target.write_text(render_self_hosted_workflow(test_command, with_pull_request))
+    return True

--- a/src/mcli/workflow/ci/workflow_transform.py
+++ b/src/mcli/workflow/ci/workflow_transform.py
@@ -31,3 +31,73 @@ def runs_on_is_hosted(runs_on) -> bool:
     if "${{" in text:
         return True  # unknown matrix/expression -> assume hosted to stop cost
     return is_hosted_label(text)
+
+
+# NOTE: ruamel.yaml round-trip (YAML(), typ='rt') is the SAFE, correct loader here.
+# It does NOT execute `!!python/object` tags like PyYAML's yaml.load(). Do not
+# "fix" this to PyYAML safe_load — that would strip comments/formatting and break
+# round-tripping. Round-trip preservation is a hard requirement of this transform.
+def _yaml() -> YAML:
+    y = YAML()
+    y.version = (1, 2)        # critical: keeps bare `on:` a string, not boolean True
+    y.preserve_quotes = True
+    y.width = 4096            # avoid reflowing long lines
+    y.indent(mapping=2, sequence=4, offset=2)
+    return y
+
+
+def workflow_has_hosted_job(doc) -> bool:
+    """True if any job in the parsed workflow targets a GitHub-hosted runner."""
+    if not isinstance(doc, dict):
+        return False
+    jobs = doc.get("jobs") or {}
+    for job in jobs.values():
+        if isinstance(job, dict) and runs_on_is_hosted(job.get("runs-on")):
+            return True
+    return False
+
+
+def strip_hosted_triggers(doc) -> bool:
+    """Remove push/pull_request from `on:`, ensure workflow_dispatch. Returns changed."""
+    on = doc.get("on")
+    if on is None:
+        return False
+    changed = False
+    if isinstance(on, dict):
+        for key in ("push", "pull_request"):
+            if key in on:
+                del on[key]
+                changed = True
+        if "workflow_dispatch" not in on:
+            on["workflow_dispatch"] = None
+            changed = True
+    elif isinstance(on, list):
+        kept = [x for x in on if x not in ("push", "pull_request")]
+        if "workflow_dispatch" not in kept:
+            kept.append("workflow_dispatch")
+        if kept != list(on):
+            doc["on"] = kept
+            changed = True
+    elif isinstance(on, str):
+        if on in ("push", "pull_request"):
+            doc["on"] = "workflow_dispatch"
+            changed = True
+    return changed
+
+
+def transform_file(path: Path) -> bool:
+    """Strip hosted triggers in-place if the workflow has a hosted job. Idempotent."""
+    path = Path(path)
+    text = path.read_text()
+    if MARKER in text:
+        return False
+    yaml = _yaml()
+    doc = yaml.load(text)
+    if not workflow_has_hosted_job(doc):
+        return False
+    strip_hosted_triggers(doc)
+    doc.yaml_set_start_comment(f"{MARKER}\n")
+    buf = StringIO()
+    yaml.dump(doc, buf)
+    path.write_text(buf.getvalue())
+    return True

--- a/tests/unit/workflow/test_ci_act_runner.py
+++ b/tests/unit/workflow/test_ci_act_runner.py
@@ -1,0 +1,52 @@
+"""Unit tests for ci.act_runner."""
+import subprocess
+from unittest.mock import patch
+
+from mcli.workflow.ci.act_runner import (
+    PreflightResult, probe, run_act, build_act_command,
+)
+
+
+def _cp(returncode=0, stdout=""):
+    return subprocess.CompletedProcess(args=["act"], returncode=returncode, stdout=stdout, stderr="")
+
+
+class TestProbe:
+    def test_probe_false_when_act_missing(self):
+        with patch("shutil.which", return_value=None):
+            assert probe() is False
+
+    def test_probe_false_when_docker_down(self):
+        with patch("shutil.which", return_value="/usr/bin/act"), \
+             patch("mcli.workflow.ci.act_runner.docker_running", return_value=False):
+            assert probe() is False
+
+    def test_probe_true_when_all_ok(self):
+        with patch("shutil.which", return_value="/usr/bin/act"), \
+             patch("mcli.workflow.ci.act_runner.docker_running", return_value=True), \
+             patch("subprocess.run", return_value=_cp(0)):
+            assert probe() is True
+
+
+class TestBuildCommand:
+    def test_adds_secret_file_when_present(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".secrets").write_text("X=1\n")
+        cmd = build_act_command("pull_request")
+        assert cmd[:2] == ["act", "pull_request"]
+        assert "--secret-file" in cmd
+
+    def test_no_secret_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cmd = build_act_command("push")
+        assert "--secret-file" not in cmd
+
+
+class TestRunAct:
+    def test_pass(self):
+        with patch("subprocess.run", return_value=_cp(0)):
+            assert run_act("pull_request") == PreflightResult.PASS
+
+    def test_fail(self):
+        with patch("subprocess.run", return_value=_cp(1)):
+            assert run_act("pull_request") == PreflightResult.FAIL

--- a/tests/unit/workflow/test_ci_act_runner.py
+++ b/tests/unit/workflow/test_ci_act_runner.py
@@ -50,3 +50,23 @@ class TestRunAct:
     def test_fail(self):
         with patch("subprocess.run", return_value=_cp(1)):
             assert run_act("pull_request") == PreflightResult.FAIL
+
+
+from mcli.workflow.ci.act_runner import preflight
+
+
+class TestPreflight:
+    def test_act_passes(self):
+        with patch("mcli.workflow.ci.act_runner.probe", return_value=True), \
+             patch("mcli.workflow.ci.act_runner.run_act", return_value=PreflightResult.PASS):
+            assert preflight("o/r") == PreflightResult.PASS
+
+    def test_act_fails_blocks(self):
+        with patch("mcli.workflow.ci.act_runner.probe", return_value=True), \
+             patch("mcli.workflow.ci.act_runner.run_act", return_value=PreflightResult.FAIL):
+            assert preflight("o/r") == PreflightResult.FAIL
+
+    def test_unreachable_with_runner_is_unreachable(self):
+        # Fallback to runner is handled by the CLI layer; preflight reports UNREACHABLE.
+        with patch("mcli.workflow.ci.act_runner.probe", return_value=False):
+            assert preflight("o/r") == PreflightResult.UNREACHABLE

--- a/tests/unit/workflow/test_ci_act_runner.py
+++ b/tests/unit/workflow/test_ci_act_runner.py
@@ -1,14 +1,15 @@
 """Unit tests for ci.act_runner."""
+
 import subprocess
 from unittest.mock import patch
 
-from mcli.workflow.ci.act_runner import (
-    PreflightResult, probe, run_act, build_act_command,
-)
+from mcli.workflow.ci.act_runner import PreflightResult, build_act_command, probe, run_act
 
 
 def _cp(returncode=0, stdout=""):
-    return subprocess.CompletedProcess(args=["act"], returncode=returncode, stdout=stdout, stderr="")
+    return subprocess.CompletedProcess(
+        args=["act"], returncode=returncode, stdout=stdout, stderr=""
+    )
 
 
 class TestProbe:
@@ -17,14 +18,18 @@ class TestProbe:
             assert probe() is False
 
     def test_probe_false_when_docker_down(self):
-        with patch("shutil.which", return_value="/usr/bin/act"), \
-             patch("mcli.workflow.ci.act_runner.docker_running", return_value=False):
+        with (
+            patch("shutil.which", return_value="/usr/bin/act"),
+            patch("mcli.workflow.ci.act_runner.docker_running", return_value=False),
+        ):
             assert probe() is False
 
     def test_probe_true_when_all_ok(self):
-        with patch("shutil.which", return_value="/usr/bin/act"), \
-             patch("mcli.workflow.ci.act_runner.docker_running", return_value=True), \
-             patch("subprocess.run", return_value=_cp(0)):
+        with (
+            patch("shutil.which", return_value="/usr/bin/act"),
+            patch("mcli.workflow.ci.act_runner.docker_running", return_value=True),
+            patch("subprocess.run", return_value=_cp(0)),
+        ):
             assert probe() is True
 
 
@@ -57,13 +62,17 @@ from mcli.workflow.ci.act_runner import preflight
 
 class TestPreflight:
     def test_act_passes(self):
-        with patch("mcli.workflow.ci.act_runner.probe", return_value=True), \
-             patch("mcli.workflow.ci.act_runner.run_act", return_value=PreflightResult.PASS):
+        with (
+            patch("mcli.workflow.ci.act_runner.probe", return_value=True),
+            patch("mcli.workflow.ci.act_runner.run_act", return_value=PreflightResult.PASS),
+        ):
             assert preflight("o/r") == PreflightResult.PASS
 
     def test_act_fails_blocks(self):
-        with patch("mcli.workflow.ci.act_runner.probe", return_value=True), \
-             patch("mcli.workflow.ci.act_runner.run_act", return_value=PreflightResult.FAIL):
+        with (
+            patch("mcli.workflow.ci.act_runner.probe", return_value=True),
+            patch("mcli.workflow.ci.act_runner.run_act", return_value=PreflightResult.FAIL),
+        ):
             assert preflight("o/r") == PreflightResult.FAIL
 
     def test_unreachable_with_runner_is_unreachable(self):

--- a/tests/unit/workflow/test_ci_cli.py
+++ b/tests/unit/workflow/test_ci_cli.py
@@ -1,0 +1,47 @@
+"""CliRunner tests for the `mcli ci` group."""
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from mcli.workflow.ci.ci import ci
+
+HOSTED_WF = """\
+name: ci
+on:
+  push:
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+"""
+
+
+class TestMigrate:
+    def test_migrate_strips_triggers_and_adds_fallback(self, tmp_path, monkeypatch):
+        wfdir = tmp_path / ".github" / "workflows"
+        wfdir.mkdir(parents=True)
+        (wfdir / "ci.yml").write_text(HOSTED_WF)
+        monkeypatch.chdir(tmp_path)
+        with patch("mcli.workflow.ci.ci.has_online_runner", return_value=False), \
+             patch("mcli.workflow.ci.ci.detect_test_command", return_value="make test"):
+            res = CliRunner().invoke(ci, ["migrate"])
+        assert res.exit_code == 0, res.output
+        out = (wfdir / "ci.yml").read_text()
+        assert "push:" not in out and "pull_request:" not in out
+        assert (wfdir / "self-hosted-ci.yml").exists()
+        # no runner -> fallback has no pull_request trigger
+        assert "pull_request:" not in (wfdir / "self-hosted-ci.yml").read_text()
+
+    def test_migrate_dry_run_makes_no_changes(self, tmp_path, monkeypatch):
+        wfdir = tmp_path / ".github" / "workflows"
+        wfdir.mkdir(parents=True)
+        (wfdir / "ci.yml").write_text(HOSTED_WF)
+        monkeypatch.chdir(tmp_path)
+        with patch("mcli.workflow.ci.ci.has_online_runner", return_value=False), \
+             patch("mcli.workflow.ci.ci.detect_test_command", return_value="make test"):
+            res = CliRunner().invoke(ci, ["migrate", "--dry-run"])
+        assert res.exit_code == 0
+        assert (wfdir / "ci.yml").read_text() == HOSTED_WF  # unchanged
+        assert not (wfdir / "self-hosted-ci.yml").exists()

--- a/tests/unit/workflow/test_ci_cli.py
+++ b/tests/unit/workflow/test_ci_cli.py
@@ -1,4 +1,5 @@
 """CliRunner tests for the `mcli ci` group."""
+
 from unittest.mock import patch
 
 from click.testing import CliRunner
@@ -24,8 +25,10 @@ class TestMigrate:
         wfdir.mkdir(parents=True)
         (wfdir / "ci.yml").write_text(HOSTED_WF)
         monkeypatch.chdir(tmp_path)
-        with patch("mcli.workflow.ci.ci.has_online_runner", return_value=False), \
-             patch("mcli.workflow.ci.ci.detect_test_command", return_value="make test"):
+        with (
+            patch("mcli.workflow.ci.ci.has_online_runner", return_value=False),
+            patch("mcli.workflow.ci.ci.detect_test_command", return_value="make test"),
+        ):
             res = CliRunner().invoke(ci, ["migrate"])
         assert res.exit_code == 0, res.output
         out = (wfdir / "ci.yml").read_text()
@@ -39,8 +42,10 @@ class TestMigrate:
         wfdir.mkdir(parents=True)
         (wfdir / "ci.yml").write_text(HOSTED_WF)
         monkeypatch.chdir(tmp_path)
-        with patch("mcli.workflow.ci.ci.has_online_runner", return_value=False), \
-             patch("mcli.workflow.ci.ci.detect_test_command", return_value="make test"):
+        with (
+            patch("mcli.workflow.ci.ci.has_online_runner", return_value=False),
+            patch("mcli.workflow.ci.ci.detect_test_command", return_value="make test"),
+        ):
             res = CliRunner().invoke(ci, ["migrate", "--dry-run"])
         assert res.exit_code == 0
         assert (wfdir / "ci.yml").read_text() == HOSTED_WF  # unchanged
@@ -52,9 +57,11 @@ from mcli.workflow.ci.act_runner import PreflightResult
 
 class TestPreflightCommand:
     def _run(self, result, has_runner):
-        with patch("mcli.workflow.ci.ci.current_repo_slug", return_value="o/r"), \
-             patch("mcli.workflow.ci.ci.preflight_fn", return_value=result), \
-             patch("mcli.workflow.ci.ci.has_online_runner", return_value=has_runner):
+        with (
+            patch("mcli.workflow.ci.ci.current_repo_slug", return_value="o/r"),
+            patch("mcli.workflow.ci.ci.preflight_fn", return_value=result),
+            patch("mcli.workflow.ci.ci.has_online_runner", return_value=has_runner),
+        ):
             return CliRunner().invoke(ci, ["preflight"])
 
     def test_pass_exit_0(self):
@@ -76,10 +83,12 @@ class TestPreflightCommand:
 
 class TestDoctorAndHook:
     def test_doctor_reports_status(self):
-        with patch("mcli.workflow.ci.ci.act_available", return_value=True), \
-             patch("mcli.workflow.ci.ci.docker_running", return_value=False), \
-             patch("mcli.workflow.ci.ci.current_repo_slug", return_value="o/r"), \
-             patch("mcli.workflow.ci.ci.has_online_runner", return_value=False):
+        with (
+            patch("mcli.workflow.ci.ci.act_available", return_value=True),
+            patch("mcli.workflow.ci.ci.docker_running", return_value=False),
+            patch("mcli.workflow.ci.ci.current_repo_slug", return_value="o/r"),
+            patch("mcli.workflow.ci.ci.has_online_runner", return_value=False),
+        ):
             res = CliRunner().invoke(ci, ["doctor"])
         assert res.exit_code == 0
         assert "act" in res.output.lower()
@@ -102,10 +111,12 @@ from mcli.workflow.ci import ci as ci_mod
 
 class TestPrCommand:
     def _invoke(self, result, has_runner):
-        with patch("mcli.workflow.ci.ci.current_repo_slug", return_value="o/r"), \
-             patch("mcli.workflow.ci.ci.preflight_fn", return_value=result), \
-             patch("mcli.workflow.ci.ci.has_online_runner", return_value=has_runner), \
-             patch("mcli.workflow.ci.ci.subprocess.run") as run:
+        with (
+            patch("mcli.workflow.ci.ci.current_repo_slug", return_value="o/r"),
+            patch("mcli.workflow.ci.ci.preflight_fn", return_value=result),
+            patch("mcli.workflow.ci.ci.has_online_runner", return_value=has_runner),
+            patch("mcli.workflow.ci.ci.subprocess.run") as run,
+        ):
             res = CliRunner().invoke(ci, ["pr"])
         return res, run
 

--- a/tests/unit/workflow/test_ci_cli.py
+++ b/tests/unit/workflow/test_ci_cli.py
@@ -45,3 +45,30 @@ class TestMigrate:
         assert res.exit_code == 0
         assert (wfdir / "ci.yml").read_text() == HOSTED_WF  # unchanged
         assert not (wfdir / "self-hosted-ci.yml").exists()
+
+
+from mcli.workflow.ci.act_runner import PreflightResult
+
+
+class TestPreflightCommand:
+    def _run(self, result, has_runner):
+        with patch("mcli.workflow.ci.ci.current_repo_slug", return_value="o/r"), \
+             patch("mcli.workflow.ci.ci.preflight_fn", return_value=result), \
+             patch("mcli.workflow.ci.ci.has_online_runner", return_value=has_runner):
+            return CliRunner().invoke(ci, ["preflight"])
+
+    def test_pass_exit_0(self):
+        assert self._run(PreflightResult.PASS, False).exit_code == 0
+
+    def test_fail_exit_1(self):
+        assert self._run(PreflightResult.FAIL, False).exit_code == 1
+
+    def test_unreachable_no_runner_exit_2(self):
+        res = self._run(PreflightResult.UNREACHABLE, False)
+        assert res.exit_code == 2
+        assert "cannot validate" in res.output.lower()
+
+    def test_unreachable_with_runner_exit_3(self):
+        res = self._run(PreflightResult.UNREACHABLE, True)
+        assert res.exit_code == 3  # signals: push and let runner validate
+        assert "runner" in res.output.lower()

--- a/tests/unit/workflow/test_ci_cli.py
+++ b/tests/unit/workflow/test_ci_cli.py
@@ -72,3 +72,26 @@ class TestPreflightCommand:
         res = self._run(PreflightResult.UNREACHABLE, True)
         assert res.exit_code == 3  # signals: push and let runner validate
         assert "runner" in res.output.lower()
+
+
+class TestDoctorAndHook:
+    def test_doctor_reports_status(self):
+        with patch("mcli.workflow.ci.ci.act_available", return_value=True), \
+             patch("mcli.workflow.ci.ci.docker_running", return_value=False), \
+             patch("mcli.workflow.ci.ci.current_repo_slug", return_value="o/r"), \
+             patch("mcli.workflow.ci.ci.has_online_runner", return_value=False):
+            res = CliRunner().invoke(ci, ["doctor"])
+        assert res.exit_code == 0
+        assert "act" in res.output.lower()
+        assert "docker" in res.output.lower()
+
+    def test_install_hook_writes_pre_push(self, tmp_path, monkeypatch):
+        hooks = tmp_path / ".git" / "hooks"
+        hooks.mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+        res = CliRunner().invoke(ci, ["install-hook"])
+        assert res.exit_code == 0
+        hook = hooks / "pre-push"
+        assert hook.exists()
+        assert "mcli ci preflight" in hook.read_text()
+        assert hook.stat().st_mode & 0o111  # executable

--- a/tests/unit/workflow/test_ci_cli.py
+++ b/tests/unit/workflow/test_ci_cli.py
@@ -95,3 +95,58 @@ class TestDoctorAndHook:
         assert hook.exists()
         assert "mcli ci preflight" in hook.read_text()
         assert hook.stat().st_mode & 0o111  # executable
+
+
+from mcli.workflow.ci import ci as ci_mod
+
+
+class TestPrCommand:
+    def _invoke(self, result, has_runner):
+        with patch("mcli.workflow.ci.ci.current_repo_slug", return_value="o/r"), \
+             patch("mcli.workflow.ci.ci.preflight_fn", return_value=result), \
+             patch("mcli.workflow.ci.ci.has_online_runner", return_value=has_runner), \
+             patch("mcli.workflow.ci.ci.subprocess.run") as run:
+            res = CliRunner().invoke(ci, ["pr"])
+        return res, run
+
+    def test_pr_pass_creates_pr(self):
+        res, run = self._invoke(PreflightResult.PASS, False)
+        assert res.exit_code == 0, res.output
+        assert run.call_count == 1  # gh pr create
+
+    def test_pr_fail_exit_1_no_shell(self):
+        res, run = self._invoke(PreflightResult.FAIL, False)
+        assert res.exit_code == 1
+        run.assert_not_called()
+
+    def test_pr_unreachable_no_runner_exit_2(self):
+        res, run = self._invoke(PreflightResult.UNREACHABLE, False)
+        assert res.exit_code == 2
+        run.assert_not_called()
+
+    def test_pr_unreachable_with_runner_pushes_then_prs(self):
+        res, run = self._invoke(PreflightResult.UNREACHABLE, True)
+        assert res.exit_code == 0, res.output
+        assert run.call_count == 2  # git push + gh pr create
+
+
+class TestRepoSlug:
+    def _slug(self, url):
+        cp = type("CP", (), {"stdout": url, "returncode": 0})()
+        with patch("mcli.workflow.ci.ci.subprocess.run", return_value=cp):
+            return ci_mod.current_repo_slug()
+
+    def test_https_github(self):
+        assert self._slug("https://github.com/owner/repo.git\n") == "owner/repo"
+
+    def test_ssh_github(self):
+        assert self._slug("git@github.com:owner/repo.git") == "owner/repo"
+
+    def test_https_no_dotgit_trailing_slash(self):
+        assert self._slug("https://github.com/owner/repo/") == "owner/repo"
+
+    def test_non_github_returns_none(self):
+        assert self._slug("git@bitbucket.org:owner/repo.git") is None
+
+    def test_ghe_returns_none(self):
+        assert self._slug("https://github.example.com/owner/repo.git") is None

--- a/tests/unit/workflow/test_ci_runner_status.py
+++ b/tests/unit/workflow/test_ci_runner_status.py
@@ -1,4 +1,5 @@
 """Unit tests for ci.runner_status."""
+
 import json
 import subprocess
 from unittest.mock import patch

--- a/tests/unit/workflow/test_ci_runner_status.py
+++ b/tests/unit/workflow/test_ci_runner_status.py
@@ -1,0 +1,34 @@
+"""Unit tests for ci.runner_status."""
+import json
+import subprocess
+from unittest.mock import patch
+
+from mcli.workflow.ci.runner_status import has_online_runner
+
+
+def _completed(stdout="", returncode=0):
+    return subprocess.CompletedProcess(args=["gh"], returncode=returncode, stdout=stdout, stderr="")
+
+
+class TestHasOnlineRunner:
+    def test_online_runner_present(self):
+        payload = json.dumps({"total_count": 1, "runners": [{"status": "online"}]})
+        with patch("subprocess.run", return_value=_completed(payload)):
+            assert has_online_runner("gwicho38/mcli") is True
+
+    def test_only_offline_runner(self):
+        payload = json.dumps({"total_count": 1, "runners": [{"status": "offline"}]})
+        with patch("subprocess.run", return_value=_completed(payload)):
+            assert has_online_runner("gwicho38/x") is False
+
+    def test_no_runners(self):
+        with patch("subprocess.run", return_value=_completed('{"total_count":0,"runners":[]}')):
+            assert has_online_runner("gwicho38/x") is False
+
+    def test_gh_error_returns_false(self):
+        with patch("subprocess.run", return_value=_completed("", returncode=1)):
+            assert has_online_runner("gwicho38/x") is False
+
+    def test_gh_missing_returns_false(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            assert has_online_runner("gwicho38/x") is False

--- a/tests/unit/workflow/test_ci_transform.py
+++ b/tests/unit/workflow/test_ci_transform.py
@@ -107,6 +107,37 @@ class TestStripTriggers:
         assert transform_file(wf) is False
         assert "pull_request:" in wf.read_text()  # untouched
 
+    def test_strip_list_form_on(self, tmp_path):
+        wf = tmp_path / "ci.yml"
+        wf.write_text(
+            "name: ci\n"
+            "on: [push, pull_request]\n"
+            "jobs:\n"
+            "  test:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - run: echo hi\n"
+        )
+        assert transform_file(wf) is True
+        out = wf.read_text()
+        assert "push" not in out
+        assert "pull_request" not in out
+        assert "workflow_dispatch" in out
+
+    def test_strip_string_form_on(self, tmp_path):
+        wf = tmp_path / "ci.yml"
+        wf.write_text(
+            "name: ci\n"
+            "on: push\n"
+            "jobs:\n"
+            "  test:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - run: echo hi\n"
+        )
+        assert transform_file(wf) is True
+        assert "workflow_dispatch" in wf.read_text()
+
 
 from mcli.workflow.ci.workflow_transform import (
     render_self_hosted_workflow, write_self_hosted_workflow, SELF_HOSTED_FILENAME,

--- a/tests/unit/workflow/test_ci_transform.py
+++ b/tests/unit/workflow/test_ci_transform.py
@@ -1,14 +1,21 @@
 """Unit tests for ci.workflow_transform."""
+
 import pytest
-from mcli.workflow.ci.workflow_transform import runs_on_is_hosted, is_hosted_label
+
+from mcli.workflow.ci.workflow_transform import is_hosted_label, runs_on_is_hosted
 
 
 class TestRunsOnClassification:
-    @pytest.mark.parametrize("label,expected", [
-        ("ubuntu-latest", True), ("ubuntu-22.04", True),
-        ("macos-14", True), ("windows-latest", True),
-        ("self-hosted", False),
-    ])
+    @pytest.mark.parametrize(
+        "label,expected",
+        [
+            ("ubuntu-latest", True),
+            ("ubuntu-22.04", True),
+            ("macos-14", True),
+            ("windows-latest", True),
+            ("self-hosted", False),
+        ],
+    )
     def test_is_hosted_label(self, label, expected):
         assert is_hosted_label(label) is expected
 
@@ -35,9 +42,7 @@ class TestRunsOnClassification:
         assert runs_on_is_hosted(None) is False
 
 
-from mcli.workflow.ci.workflow_transform import (
-    workflow_has_hosted_job, transform_file, MARKER,
-)
+from mcli.workflow.ci.workflow_transform import MARKER, transform_file, workflow_has_hosted_job
 
 HOSTED_WF = """\
 name: ci
@@ -68,6 +73,7 @@ jobs:
 class TestStripTriggers:
     def _load(self, text):
         from ruamel.yaml import YAML
+
         y = YAML()
         y.version = (1, 2)  # keep 'on' a string key, not boolean True
         return y.load(text)
@@ -150,7 +156,9 @@ class TestStripTriggers:
 
 
 from mcli.workflow.ci.workflow_transform import (
-    render_self_hosted_workflow, write_self_hosted_workflow, SELF_HOSTED_FILENAME,
+    SELF_HOSTED_FILENAME,
+    render_self_hosted_workflow,
+    write_self_hosted_workflow,
 )
 
 

--- a/tests/unit/workflow/test_ci_transform.py
+++ b/tests/unit/workflow/test_ci_transform.py
@@ -138,6 +138,16 @@ class TestStripTriggers:
         assert transform_file(wf) is True
         assert "workflow_dispatch" in wf.read_text()
 
+    def test_no_yaml_directive_in_output(self, tmp_path):
+        # Pinning ruamel to YAML 1.2 to keep `on` a string must NOT leak a
+        # `%YAML 1.2` / `---` directive into the workflow file.
+        wf = tmp_path / "ci.yml"
+        wf.write_text(HOSTED_WF)
+        transform_file(wf)
+        out = wf.read_text()
+        assert "%YAML" not in out
+        assert not out.lstrip().startswith("---")
+
 
 from mcli.workflow.ci.workflow_transform import (
     render_self_hosted_workflow, write_self_hosted_workflow, SELF_HOSTED_FILENAME,

--- a/tests/unit/workflow/test_ci_transform.py
+++ b/tests/unit/workflow/test_ci_transform.py
@@ -33,3 +33,76 @@ class TestRunsOnClassification:
 
     def test_none(self):
         assert runs_on_is_hosted(None) is False
+
+
+from mcli.workflow.ci.workflow_transform import (
+    workflow_has_hosted_job, transform_file, MARKER,
+)
+
+HOSTED_WF = """\
+name: ci
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+"""
+
+SELFHOSTED_WF = """\
+name: ci
+on:
+  pull_request:
+jobs:
+  test:
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - run: echo hi
+"""
+
+
+class TestStripTriggers:
+    def _load(self, text):
+        from ruamel.yaml import YAML
+        y = YAML()
+        y.version = (1, 2)  # keep 'on' a string key, not boolean True
+        return y.load(text)
+
+    def test_detects_hosted_job(self):
+        assert workflow_has_hosted_job(self._load(HOSTED_WF)) is True
+
+    def test_detects_self_hosted_only(self):
+        assert workflow_has_hosted_job(self._load(SELFHOSTED_WF)) is False
+
+    def test_transform_strips_push_and_pr(self, tmp_path):
+        wf = tmp_path / "ci.yml"
+        wf.write_text(HOSTED_WF)
+        changed = transform_file(wf)
+        out = wf.read_text()
+        assert changed is True
+        assert MARKER in out
+        assert "push:" not in out
+        assert "pull_request:" not in out
+        assert "workflow_dispatch:" in out
+        # 'on:' must survive as a string key, not become 'true:'
+        assert "\non:" in out
+        assert "\ntrue:" not in out
+
+    def test_transform_idempotent(self, tmp_path):
+        wf = tmp_path / "ci.yml"
+        wf.write_text(HOSTED_WF)
+        transform_file(wf)
+        first = wf.read_text()
+        changed_again = transform_file(wf)
+        assert changed_again is False
+        assert wf.read_text() == first
+
+    def test_transform_skips_self_hosted_only(self, tmp_path):
+        wf = tmp_path / "ci.yml"
+        wf.write_text(SELFHOSTED_WF)
+        assert transform_file(wf) is False
+        assert "pull_request:" in wf.read_text()  # untouched

--- a/tests/unit/workflow/test_ci_transform.py
+++ b/tests/unit/workflow/test_ci_transform.py
@@ -106,3 +106,35 @@ class TestStripTriggers:
         wf.write_text(SELFHOSTED_WF)
         assert transform_file(wf) is False
         assert "pull_request:" in wf.read_text()  # untouched
+
+
+from mcli.workflow.ci.workflow_transform import (
+    render_self_hosted_workflow, write_self_hosted_workflow, SELF_HOSTED_FILENAME,
+)
+
+
+class TestSelfHostedWorkflow:
+    def test_render_includes_dispatch_always(self):
+        out = render_self_hosted_workflow("make test", with_pull_request=False)
+        assert "workflow_dispatch:" in out
+        assert "pull_request:" not in out
+        assert "runs-on: [self-hosted, Linux, X64]" in out
+        assert "make test" in out
+
+    def test_render_adds_pr_when_runner_present(self):
+        out = render_self_hosted_workflow("pytest", with_pull_request=True)
+        assert "pull_request:" in out
+        assert "${{ github.ref }}" in out  # concurrency expression intact
+
+    def test_write_creates_file(self, tmp_path):
+        wfdir = tmp_path / ".github" / "workflows"
+        wfdir.mkdir(parents=True)
+        created = write_self_hosted_workflow(wfdir, "make test", with_pull_request=True)
+        assert created is True
+        assert (wfdir / SELF_HOSTED_FILENAME).exists()
+
+    def test_write_is_idempotent(self, tmp_path):
+        wfdir = tmp_path / ".github" / "workflows"
+        wfdir.mkdir(parents=True)
+        write_self_hosted_workflow(wfdir, "make test", with_pull_request=True)
+        assert write_self_hosted_workflow(wfdir, "make test", with_pull_request=True) is False

--- a/tests/unit/workflow/test_ci_transform.py
+++ b/tests/unit/workflow/test_ci_transform.py
@@ -1,0 +1,35 @@
+"""Unit tests for ci.workflow_transform."""
+import pytest
+from mcli.workflow.ci.workflow_transform import runs_on_is_hosted, is_hosted_label
+
+
+class TestRunsOnClassification:
+    @pytest.mark.parametrize("label,expected", [
+        ("ubuntu-latest", True), ("ubuntu-22.04", True),
+        ("macos-14", True), ("windows-latest", True),
+        ("self-hosted", False),
+    ])
+    def test_is_hosted_label(self, label, expected):
+        assert is_hosted_label(label) is expected
+
+    def test_string_hosted(self):
+        assert runs_on_is_hosted("ubuntu-latest") is True
+
+    def test_string_self_hosted(self):
+        assert runs_on_is_hosted("self-hosted") is False
+
+    def test_list_with_self_hosted_is_not_hosted(self):
+        assert runs_on_is_hosted(["self-hosted", "Linux", "X64"]) is False
+
+    def test_list_hosted(self):
+        assert runs_on_is_hosted(["ubuntu-latest"]) is True
+
+    def test_matrix_expression_is_conservatively_hosted(self):
+        # Unknown expansion -> assume hosted so we err toward stopping cost.
+        assert runs_on_is_hosted("${{ matrix.os }}") is True
+
+    def test_expression_referencing_self_hosted_is_not_hosted(self):
+        assert runs_on_is_hosted("${{ inputs.x }}-self-hosted") is False
+
+    def test_none(self):
+        assert runs_on_is_hosted(None) is False

--- a/uv.lock
+++ b/uv.lock
@@ -4065,6 +4065,7 @@ dependencies = [
     { name = "redis" },
     { name = "requests" },
     { name = "rich" },
+    { name = "ruamel-yaml" },
     { name = "scikit-image", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-image", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary
Adds an `mcli ci` command group implementing **act-first CI**: local [`act`](https://github.com/nektos/act) becomes the primary PR gate, and GitHub-hosted `push`/`pull_request` triggers are stripped from workflows so private repos stop consuming billed Actions minutes. A dormant `self-hosted-ci.yml` fallback is added, gaining a `pull_request` trigger only where an online self-hosted runner exists.

## Commands
- `mcli ci migrate [--dry-run]` — strip hosted triggers + add self-hosted fallback (idempotent)
- `mcli ci preflight [--event]` — run act as the gate (exit 0=pass, 1=fail, 2=cannot-validate, 3=use-runner)
- `mcli ci pr` — preflight then `gh pr create`
- `mcli ci doctor` — act/docker/runner status
- `mcli ci install-hook` — opt-in pre-push hook

## Notes
- `ruamel.yaml` added (round-trip preserves workflow comments/formatting); pinned `version=(1,2)` keeps bare `on:` a string (avoids the YAML 1.1 `on→true` footgun) and is reset before dump so no `%YAML` directive leaks into workflow files.
- `current_repo_slug` only resolves `github.com` remotes.
- 56 unit tests; black/isort/flake8/mypy clean.

Docs: `docs/commands/ci.md`

## Summary by Sourcery

Add an act-first CI command group that migrates GitHub Actions workflows away from hosted triggers and introduces a self-hosted fallback path for private repositories.

New Features:
- Introduce the `mcli ci` command group with subcommands for migration, local preflight checks, PR creation, environment diagnostics, and installing a pre-push hook.
- Add workflow transformation utilities to strip hosted runner triggers from GitHub Actions workflows while preserving formatting and comments, and to generate a self-hosted fallback workflow.
- Implement local `act` integration and probing logic to gate pull requests based on local workflow execution results.
- Add GitHub runner status querying via the `gh` CLI to detect the presence of online self-hosted runners and drive fallback behaviour.

Enhancements:
- Add ruamel.yaml as a dependency to support safe, round-trippable editing of GitHub Actions workflow files.

Build:
- Bump the framework version to 8.0.49.

Documentation:
- Add user-facing documentation for the new `mcli ci` command group and its behaviour, including exit codes and migration semantics.

Tests:
- Add unit tests covering CI workflow transformation, act runner behaviour, CLI commands, and self-hosted runner status detection.