### PR TITLE
fix(ci): invoke twine/pip via python -m

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,17 +91,17 @@ jobs:
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build twine
+          python -m pip install build twine
 
       - name: Build package
         run: python -m build
 
       - name: Check distribution
-        run: twine check dist/*
+        run: python -m twine check dist/*
 
       - name: Test basic functionality
         run: |
-          pip install dist/*.whl
+          python -m pip install dist/*.whl
           mcli --help || echo "CLI not found in PATH"
           python -c "import mcli; print('mcli import successful')"
 


### PR DESCRIPTION
After the self-hosted runner's Python tool cache fix, build job failed at `twine check dist/*` because pip's user-install put twine outside the runner's PATH. Use `python -m twine` / `python -m pip` so module-resolution finds them regardless of PATH.

## Summary by Sourcery

CI:
- Update the publish workflow to use `python -m pip` and `python -m twine` instead of relying on pip and twine being on PATH.