### PR TITLE
fix(sync): repair core IPFS/IPNS workflow round-trip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ distribution
 *.code-workspace
 _*.*
 !__init__.py
+!__main__.py
 *.spec
 
 *.c

--- a/docs/releases/8.0.49.md
+++ b/docs/releases/8.0.49.md
@@ -1,0 +1,118 @@
+# Release Notes - Version 8.0.49
+
+**Release Date:** 2026-05-29
+
+## Overview
+
+Version 8.0.49 is a bug-fix release that repairs the **core `mcli sync`
+round-trip** (the lsh-parity IPFS/IPNS workflow). Three independent defects
+prevented `mcli sync` from actually distributing workflow scripts end-to-end.
+After this release a full `update → push → pull` cycle reconstructs every
+workflow script — including those organized into group subdirectories —
+byte-for-byte, and IPNS auto-resolve works for teammates on the same repo.
+
+## Bugs Fixed
+
+### 1. Lockfile filename mismatch broke every `push`/`pull` (critical)
+
+`mcli sync update` wrote the lockfile as `workflows.lock.json` (via
+`ScriptLoader`), while `mcli sync push`/`pull` read `commands.lock.json`. The
+two halves of the feature never agreed, so **every push after an update failed**
+with `Lockfile not found`. `ScriptLoader` now uses the canonical
+`FileNames.COMMANDS_LOCK_JSON`, and the remaining hardcoded literals in
+`sync_cmd.py` / `paths.py` were consolidated onto the same constant.
+
+### 2. Grouped scripts never had their bodies synced (critical)
+
+The lockfile recorded each command's `file` as a bare basename (`hello.sh`),
+dropping the group subdirectory (`demo/`). `push` therefore could not locate
+scripts living in subdirectories (the normal layout produced by
+`mcli new -g <group>`), so their bodies were never uploaded and `pull`
+reported *"manifest predates per-script CIDs"* even for a freshly-pushed
+manifest. `ScriptLoader` now records the path **relative to the workflows
+directory** (`demo/hello.sh`), and `pull_workflows` recreates the subdirectories
+on disk.
+
+### 3. `push` falsely claimed IPNS success
+
+`push` printed *"Teammates can pull latest with: mcli sync pull"* whenever a
+sync key was present — even when `publish_to_ipns` failed — giving a false
+impression that auto-resolve would work. `push` now reports the IPNS result
+honestly: it surfaces the published IPNS name on success and a clear
+`IPNS publish failed` warning (with a pull-by-CID fallback hint) otherwise.
+
+## Before / After
+
+**Before** — the two halves of `sync` are wired to different lockfiles and
+group subdirectories are lost, so nothing round-trips:
+
+```mermaid
+flowchart LR
+    U[mcli sync update] -->|writes| W[workflows.lock.json<br/>file: hello.sh]
+    P[mcli sync push] -->|reads| C[commands.lock.json]
+    C -. missing .-> X[❌ Lockfile not found]
+    W -. basename only .-> S[demo/hello.sh on disk]
+    P -. cannot locate .-> S
+    PL[mcli sync pull -w] -->|no script_cid| N[❌ No scripts restored]
+```
+
+**After** — one canonical lockfile, relative paths preserved, bodies and
+subdirectories round-trip, and IPNS status is reported truthfully:
+
+```mermaid
+flowchart LR
+    U[mcli sync update] -->|writes| C[commands.lock.json<br/>file: demo/hello.sh]
+    P[mcli sync push] -->|reads| C
+    P -->|uploads body| IPFS[(IPFS<br/>per-script CID)]
+    P -->|publish ok?| K{IPNS}
+    K -->|yes| OK[✅ Published to IPNS]
+    K -->|no| WARN[⚠️ IPNS publish failed<br/>pull by CID]
+    PL[mcli sync pull -w] -->|fetch script_cid| IPFS
+    PL -->|recreate demo/| R[✅ demo/hello.sh restored byte-for-byte]
+```
+
+## Validation
+
+Validated end-to-end against a real Kubo (IPFS 0.39.0) daemon:
+
+- `update → push → pull <CID> -w` reconstructs `demo/hello.sh` with a matching
+  SHA-256.
+- `update → push → pull -r <repo> -w` (IPNS auto-resolve, no CID) reconstructs
+  the same script byte-for-byte.
+
+New regression tests:
+
+- `test_update_writes_lockfile_that_push_reads`
+- `test_push_finds_lockfile_after_update`
+- `TestGroupedScriptRoundTrip::test_loader_records_relative_path_and_push_uploads_subdir_script`
+- `TestGroupedScriptRoundTrip::test_pull_workflows_reconstructs_subdirectories`
+- `test_push_warns_when_ipns_publish_fails`
+- `test_push_reports_ipns_success_when_published`
+
+## Files Changed
+
+- `src/mcli/lib/script_loader.py` — canonical lockfile name + relative `file` path
+- `src/mcli/lib/ipfs_sync.py` — recreate subdirs on pull; track IPNS publish result
+- `src/mcli/app/sync_cmd.py` — honest IPNS reporting; constant-based lockfile path
+- `src/mcli/lib/paths.py` — `get_lockfile_path` uses the shared constant
+- `src/mcli/lib/constants/messages.py` — `IPNS_TEAMMATE_PULL_HINT`
+- `tests/unit/test_sync_cmd.py`, `tests/unit/test_ipfs_sync_script_bodies.py`
+
+## Upgrade Guide
+
+No breaking changes. Update to the new version:
+
+```bash
+uv tool install mcli-framework --force
+# or
+pip install --upgrade mcli-framework
+```
+
+Existing `workflows.lock.json` files are superseded automatically — run
+`mcli sync update` once to regenerate the canonical `commands.lock.json`.
+
+## Links
+
+- **PyPI**: https://pypi.org/project/mcli-framework/8.0.49/
+- **GitHub Release**: https://github.com/gwicho38/mcli/releases/tag/v8.0.49
+- **Full Changelog**: https://github.com/gwicho38/mcli/compare/v8.0.48...v8.0.49

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcli-framework"
-version = "8.0.48"
+version = "8.0.49"
 description = "Portable workflow framework - transform any script into a versioned, schedulable command. Store in ~/.mcli/workflows/, version with lockfile, run as daemon or cron job."
 readme = "README.md"
  requires-python = ">=3.10"

--- a/src/mcli/__main__.py
+++ b/src/mcli/__main__.py
@@ -1,0 +1,14 @@
+# logger.info("I am in mcli.__init__.py")
+
+try:
+    from mcli.app.main import main as main_func
+
+    # from mcli.public import *
+    # from mcli.private import *
+except ImportError:
+    from .app.main import main as main_func
+
+__all__ = ["main_func"]
+
+if __name__ == "__main__":
+    main_func()

--- a/src/mcli/app/sync_cmd.py
+++ b/src/mcli/app/sync_cmd.py
@@ -17,7 +17,7 @@ from typing import Optional
 import click
 from rich.table import Table
 
-from mcli.lib.constants import IpfsMessages, SyncMessages
+from mcli.lib.constants import FileNames, IpfsMessages, SyncMessages
 from mcli.lib.ipfs_utils import ipfs_daemon_running as _ipfs_daemon_running
 from mcli.lib.ipfs_utils import ipfs_initialized as _ipfs_initialized
 from mcli.lib.ipfs_utils import ipfs_installed as _ipfs_installed
@@ -423,7 +423,7 @@ def sync_push_command(global_mode: bool, description: str):
     from mcli.lib.ipns_manager import get_sync_key
 
     workflows_dir = get_custom_commands_dir(global_mode=global_mode)
-    lockfile_path = workflows_dir / "commands.lock.json"
+    lockfile_path = workflows_dir / FileNames.COMMANDS_LOCK_JSON
 
     if not lockfile_path.exists():
         error(SyncMessages.LOCKFILE_NOT_FOUND.format(path=lockfile_path))
@@ -448,10 +448,16 @@ def sync_push_command(global_mode: bool, description: str):
         console.print(SyncMessages.VIEW_BROWSER_HINT)
         console.print(SyncMessages.IPFS_GATEWAY_URL.format(cid=cid))
 
-        # Show IPNS info if published
+        # Report IPNS status honestly: only claim teammates can auto-resolve
+        # when the publish actually succeeded.
         if get_sync_key():
             console.print()
-            info("Teammates can pull latest with: mcli sync pull")
+            if ipfs.last_ipns_name:
+                success(SyncMessages.IPNS_PUBLISHED.format(name=ipfs.last_ipns_name))
+                info(SyncMessages.IPNS_TEAMMATE_PULL_HINT)
+            else:
+                warning(SyncMessages.IPNS_PUBLISH_FAILED)
+                info(SyncMessages.RETRIEVE_COMMAND.format(cid=cid))
     else:
         error(SyncMessages.FAILED_PUSH_IPFS)
 
@@ -798,7 +804,7 @@ def sync_info(is_global: bool):
     workflows_dir = get_custom_commands_dir(global_mode=is_global)
     console.print(f"  Workflows directory: {workflows_dir}")
 
-    lockfile = workflows_dir / "commands.lock.json"
+    lockfile = workflows_dir / FileNames.COMMANDS_LOCK_JSON
     console.print(f"  Lockfile: {lockfile} ({'exists' if lockfile.exists() else 'missing'})")
     console.print()
 

--- a/src/mcli/lib/constants/messages.py
+++ b/src/mcli/lib/constants/messages.py
@@ -946,6 +946,7 @@ class SyncMessages:
     IPNS_RESOLVING = "Resolving latest via IPNS..."
     IPNS_RESOLVED = "Resolved IPNS to CID: {cid}"
     IPNS_RESOLVE_FAILED = "Could not resolve via IPNS"
+    IPNS_TEAMMATE_PULL_HINT = "Teammates can pull latest with: mcli sync pull"
     IPNS_NO_SYNC_KEY = "MCLI_SYNC_KEY not set — cannot use IPNS auto-resolve"
     IPNS_SYNC_KEY_HINT = (
         "[dim]Set MCLI_SYNC_KEY to enable IPNS. Share same key with teammates.[/dim]"

--- a/src/mcli/lib/ipfs_sync.py
+++ b/src/mcli/lib/ipfs_sync.py
@@ -77,6 +77,8 @@ class IPFSSync:
         self.sync_history_path = self.data_dir / FileNames.IPFS_SYNC_HISTORY_JSON
         self.sync_history = self._load_sync_history()
         self._local_ipfs_available: Optional[bool] = None
+        # Set by push() to the IPNS name if (and only if) publish succeeded.
+        self.last_ipns_name: Optional[str] = None
 
     def _load_sync_history(self) -> list[dict]:
         """Load sync history from local storage."""
@@ -427,14 +429,17 @@ class IPFSSync:
                     self.sync_history = self.sync_history[-MAX_HISTORY:]
                 self._save_sync_history()
 
-                # Publish to IPNS if sync key is configured
+                # Publish to IPNS if sync key is configured. Record whether the
+                # publish actually succeeded so callers can report honestly
+                # instead of implying IPNS resolution works when it does not.
+                self.last_ipns_name = None
                 sync_key = get_sync_key()
                 if sync_key:
                     repo = get_repo_name()
                     key_info = derive_key_info(sync_key, repo, "global")
                     ipns_name = ensure_key_imported(key_info)
                     if ipns_name:
-                        publish_to_ipns(cid, key_info.key_name)
+                        self.last_ipns_name = publish_to_ipns(cid, key_info.key_name)
 
             return cid
 
@@ -536,6 +541,8 @@ class IPFSSync:
                     )
 
             target = workflows_dir / script_filename
+            # Recreate group subdirectories (e.g. "demo/hello.py") on pull.
+            target.parent.mkdir(parents=True, exist_ok=True)
             target.write_bytes(payload)
             written.append(target)
 

--- a/src/mcli/lib/paths.py
+++ b/src/mcli/lib/paths.py
@@ -9,7 +9,7 @@ import os
 from pathlib import Path
 from typing import Optional
 
-from mcli.lib.constants.paths import DirNames
+from mcli.lib.constants.paths import DirNames, FileNames
 
 
 def get_mcli_home() -> Path:
@@ -248,8 +248,8 @@ def get_lockfile_path(global_mode: bool = False) -> Path:
         Path to the lockfile
     """
     workflows_dir = get_custom_commands_dir(global_mode=global_mode)
-    # Keep the old lockfile name for compatibility
-    return workflows_dir / "commands.lock.json"
+    # Canonical lockfile name, shared with ScriptLoader and the IPFS sync path.
+    return workflows_dir / FileNames.COMMANDS_LOCK_JSON
 
 
 def resolve_workspace(workspace_path: str) -> Optional[Path]:

--- a/src/mcli/lib/script_loader.py
+++ b/src/mcli/lib/script_loader.py
@@ -28,6 +28,7 @@ from typing import Any, Optional
 
 import click
 
+from mcli.lib.constants import FileNames
 from mcli.lib.logger.logger import get_logger, register_subprocess
 from mcli.lib.pyenv import PyEnvManager
 
@@ -140,7 +141,10 @@ class ScriptLoader:
             workflows_dir: Directory containing workflow scripts
         """
         self.workflows_dir = Path(workflows_dir).expanduser()
-        self.lockfile_path = self.workflows_dir / "workflows.lock.json"
+        # Canonical lockfile name shared with the IPFS sync path (push/pull) and
+        # the rest of the codebase. Must match FileNames.COMMANDS_LOCK_JSON,
+        # otherwise `sync update` writes a lockfile `sync push` cannot find.
+        self.lockfile_path = self.workflows_dir / FileNames.COMMANDS_LOCK_JSON
         self.loaded_commands: dict[str, click.Command] = {}
 
     def discover_scripts(self) -> list[Path]:
@@ -383,8 +387,17 @@ class ScriptLoader:
         except Exception:
             mtime = datetime.utcnow().isoformat() + "Z"
 
+        # Record the path relative to the workflows dir (POSIX, forward slashes)
+        # so the IPFS sync path can locate and reconstruct scripts living in
+        # group subdirectories. Falls back to the bare name if the script is
+        # somehow outside the workflows dir.
+        try:
+            relative_file = script_path.relative_to(self.workflows_dir).as_posix()
+        except ValueError:
+            relative_file = script_path.name
+
         return {
-            "file": script_path.name,
+            "file": relative_file,
             "language": language,
             "content_hash": content_hash,
             "version": metadata.get("version", "1.0.0"),

--- a/tests/unit/test_ipfs_sync_script_bodies.py
+++ b/tests/unit/test_ipfs_sync_script_bodies.py
@@ -201,3 +201,74 @@ class TestPullWorkflowsExtractsScripts:
 
         assert written == []
         assert not (target / "hello.py").exists()
+
+
+class TestGroupedScriptRoundTrip:
+    """Scripts living in group subdirectories must round-trip their bodies.
+
+    Regression: ScriptLoader recorded only the basename in the lockfile
+    ``file`` field, so push() could not locate scripts stored in group
+    subdirectories (the normal layout produced by ``mcli new -g <group>``).
+    Their bodies were therefore never uploaded, and pull reported
+    "manifest predates per-script CIDs" even for a freshly-pushed manifest.
+    """
+
+    def test_loader_records_relative_path_and_push_uploads_subdir_script(self, tmp_path):
+        from mcli.lib.ipfs_sync import IPFSSync
+        from mcli.lib.script_loader import ScriptLoader
+
+        workflows_dir = tmp_path / "workflows"
+        (workflows_dir / "demo").mkdir(parents=True)
+        script = workflows_dir / "demo" / "hello.py"
+        script.write_text(SAMPLE_SCRIPT)
+
+        loader = ScriptLoader(workflows_dir)
+        assert loader.save_lockfile() is True
+
+        data = json.loads(loader.lockfile_path.read_text())
+        # The `file` field must preserve the subdir so push() can find the body.
+        assert data["commands"]["hello"]["file"] == "demo/hello.py"
+
+        sync = IPFSSync()
+        with (
+            patch.object(sync, "add_file_to_ipfs", return_value="QmScriptCid") as mock_add,
+            patch.object(sync, "upload_to_ipfs", return_value="QmManifestCid") as mock_upload,
+            patch("mcli.lib.ipfs_sync.get_sync_key", return_value=None),
+            patch.object(sync, "_save_sync_history"),
+        ):
+            cid = sync.push(loader.lockfile_path)
+
+        assert cid == "QmManifestCid"
+        mock_add.assert_called_once()
+        # push must read the body from the subdir, not the workflows root.
+        assert Path(mock_add.call_args[0][0]) == script
+        commands = mock_upload.call_args[0][0]["commands"]["commands"]
+        assert commands["hello"]["script_cid"] == "QmScriptCid"
+
+    def test_pull_workflows_reconstructs_subdirectories(self, tmp_path):
+        from mcli.lib.ipfs_sync import IPFSSync
+
+        target = tmp_path / "out"
+        target.mkdir()
+
+        manifest = {
+            "version": "2.1",
+            "commands": {
+                "hello": {
+                    "file": "demo/hello.py",
+                    "content_hash": _sha256(SAMPLE_SCRIPT),
+                    "script_cid": "QmScriptCid",
+                }
+            },
+        }
+
+        sync = IPFSSync()
+        with (
+            patch.object(sync, "pull", return_value=manifest),
+            patch.object(sync, "fetch_file_from_ipfs", return_value=SAMPLE_SCRIPT.encode()),
+        ):
+            written = sync.pull_workflows("QmManifestCid", target)
+
+        # The group subdirectory must be recreated on disk.
+        assert (target / "demo" / "hello.py").read_text() == SAMPLE_SCRIPT
+        assert written == [target / "demo" / "hello.py"]

--- a/tests/unit/test_sync_cmd.py
+++ b/tests/unit/test_sync_cmd.py
@@ -159,6 +159,71 @@ print("Test")
             # Note: Actual behavior depends on ScriptLoader implementation
             assert result.exit_code in [0, 1]  # May fail if no scripts match
 
+    def test_update_writes_lockfile_that_push_reads(self, tmp_path):
+        """Regression: `sync update` must write the SAME lockfile `sync push` reads.
+
+        Previously `update` wrote ``workflows.lock.json`` (via ScriptLoader)
+        while `push`/`pull` read ``commands.lock.json``, so every push after an
+        update failed with "Lockfile not found". The two commands MUST agree on
+        the lockfile filename.
+        """
+        from mcli.lib.constants import FileNames
+
+        runner = CliRunner()
+        workflows_dir = tmp_path / "workflows"
+        workflows_dir.mkdir()
+        (workflows_dir / "my_cmd.py").write_text(
+            "#!/usr/bin/env python3\n"
+            "# @description: My test command\n"
+            "# @version: 2.0.0\n"
+            'print("Test")\n'
+        )
+
+        with patch("mcli.app.sync_cmd.get_custom_commands_dir", return_value=workflows_dir):
+            result = runner.invoke(sync_group, ["update"])
+
+        assert result.exit_code == 0, result.output
+        # `sync push` reads exactly this path (see sync_cmd.sync_push); it MUST
+        # exist after `update`, otherwise push reports LOCKFILE_NOT_FOUND.
+        push_lockfile = workflows_dir / FileNames.COMMANDS_LOCK_JSON
+        assert push_lockfile.exists(), (
+            f"update did not create the lockfile push reads "
+            f"({FileNames.COMMANDS_LOCK_JSON}); dir contains "
+            f"{sorted(p.name for p in workflows_dir.iterdir())}"
+        )
+
+    def test_push_finds_lockfile_after_update(self, tmp_path):
+        """Regression: `sync push` locates the lockfile produced by `sync update`.
+
+        End-to-end wiring check (IPFS mocked): after `update`, `push` must NOT
+        report LOCKFILE_NOT_FOUND and must hand the produced lockfile to
+        ``IPFSSync.push``.
+        """
+        runner = CliRunner()
+        workflows_dir = tmp_path / "workflows"
+        workflows_dir.mkdir()
+        (workflows_dir / "my_cmd.py").write_text(
+            "#!/usr/bin/env python3\n# @description: c\n# @version: 1.0.0\nprint('x')\n"
+        )
+
+        with patch("mcli.app.sync_cmd.get_custom_commands_dir", return_value=workflows_dir):
+            update_result = runner.invoke(sync_group, ["update"])
+            assert update_result.exit_code == 0, update_result.output
+
+            with (
+                patch("mcli.lib.ipfs_utils.ensure_daemon_running", return_value=True),
+                patch("mcli.lib.ipfs_sync.IPFSSync") as mock_sync_cls,
+            ):
+                mock_sync_cls.return_value.push.return_value = "QmFakeCid"
+                result = runner.invoke(sync_group, ["push"])
+
+        assert "not found" not in result.output.lower(), result.output
+        mock_push = mock_sync_cls.return_value.push
+        mock_push.assert_called_once()
+        # push must receive the lockfile that `update` actually wrote.
+        called_path = Path(mock_push.call_args.args[0])
+        assert called_path.exists(), f"push received non-existent lockfile: {called_path}"
+
 
 class TestSyncPushCommand:
     """Tests for the sync push command."""
@@ -173,6 +238,60 @@ class TestSyncPushCommand:
             # Should indicate IPFS is not available
             assert result.exit_code in [0, 1]
 
+    def _setup_pushable_repo(self, tmp_path):
+        """Create a workflows dir with a lockfile that `push` can read."""
+        from click.testing import CliRunner
+
+        runner = CliRunner()
+        workflows_dir = tmp_path / "workflows"
+        workflows_dir.mkdir()
+        (workflows_dir / "c.py").write_text(
+            "#!/usr/bin/env python3\n# @description: c\n# @version: 1.0.0\nprint('x')\n"
+        )
+        with patch("mcli.app.sync_cmd.get_custom_commands_dir", return_value=workflows_dir):
+            assert runner.invoke(sync_group, ["update"]).exit_code == 0
+        return workflows_dir
+
+    def test_push_warns_when_ipns_publish_fails(self, tmp_path):
+        """Regression: push must NOT claim teammates can pull when IPNS publish failed.
+
+        Previously the IPNS hint was printed whenever a sync key was present,
+        even if ``publish_to_ipns`` silently failed (e.g. daemon had no peers),
+        giving a false impression that auto-resolve would work.
+        """
+        runner = CliRunner()
+        workflows_dir = self._setup_pushable_repo(tmp_path)
+
+        with (
+            patch("mcli.app.sync_cmd.get_custom_commands_dir", return_value=workflows_dir),
+            patch("mcli.lib.ipfs_utils.ensure_daemon_running", return_value=True),
+            patch("mcli.lib.ipns_manager.get_sync_key", return_value="k" * 64),
+            patch("mcli.lib.ipfs_sync.IPFSSync") as mock_cls,
+        ):
+            mock_cls.return_value.push.return_value = "QmCid"
+            mock_cls.return_value.last_ipns_name = None  # publish failed
+            result = runner.invoke(sync_group, ["push"])
+
+        assert "teammates can pull latest" not in result.output.lower(), result.output
+        assert "ipns publish failed" in result.output.lower(), result.output
+
+    def test_push_reports_ipns_success_when_published(self, tmp_path):
+        """When IPNS publish succeeds, push surfaces the teammate pull hint."""
+        runner = CliRunner()
+        workflows_dir = self._setup_pushable_repo(tmp_path)
+
+        with (
+            patch("mcli.app.sync_cmd.get_custom_commands_dir", return_value=workflows_dir),
+            patch("mcli.lib.ipfs_utils.ensure_daemon_running", return_value=True),
+            patch("mcli.lib.ipns_manager.get_sync_key", return_value="k" * 64),
+            patch("mcli.lib.ipfs_sync.IPFSSync") as mock_cls,
+        ):
+            mock_cls.return_value.push.return_value = "QmCid"
+            mock_cls.return_value.last_ipns_name = "k51qzi5fakeipnsname"
+            result = runner.invoke(sync_group, ["push"])
+
+        assert "teammates can pull latest" in result.output.lower(), result.output
+
 
 class TestSyncPullCommand:
     """Tests for the sync pull command."""
@@ -186,7 +305,11 @@ class TestSyncPullCommand:
 
         # Should exit cleanly but report daemon failure or IPNS error
         assert result.exit_code in [0, 1]
-        assert "daemon" in result.output.lower() or "ipns" in result.output.lower() or "sync" in result.output.lower()
+        assert (
+            "daemon" in result.output.lower()
+            or "ipns" in result.output.lower()
+            or "sync" in result.output.lower()
+        )
 
     def test_sync_pull_invalid_cid(self):
         """Test sync pull with invalid CID format."""


### PR DESCRIPTION
## Summary

Repairs the **core `mcli sync` round-trip** (the lsh-parity IPFS/IPNS workflow). Three independent defects prevented `mcli sync` from distributing workflow scripts end-to-end. Found while validating that sync actually works; fixed test-first.

### Bugs fixed
1. **Lockfile filename mismatch (critical):** `sync update` wrote `workflows.lock.json` (via `ScriptLoader`) while `sync push`/`pull` read `commands.lock.json` → every push after an update failed with *"Lockfile not found"*. `ScriptLoader` now uses the canonical `FileNames.COMMANDS_LOCK_JSON`; remaining literals consolidated onto the same constant.
2. **Grouped scripts never synced their bodies (critical):** the lockfile stored `file` as a bare basename, dropping the group subdir, so scripts from `mcli new -g <group>` were never uploaded and pull reported *"manifest predates per-script CIDs"*. Now records the path relative to the workflows dir; `pull_workflows` recreates subdirs.
3. **False IPNS success:** `push` printed *"Teammates can pull latest"* even when `publish_to_ipns` failed. Now tracks the publish result and reports honestly.

## Before / After

**Before** — two halves wired to different lockfiles; subdirs lost; nothing round-trips:

```mermaid
flowchart LR
    U[mcli sync update] -->|writes| W[workflows.lock.json<br/>file: hello.sh]
    P[mcli sync push] -->|reads| C[commands.lock.json]
    C -. missing .-> X[❌ Lockfile not found]
    W -. basename only .-> S[demo/hello.sh on disk]
    P -. cannot locate .-> S
    PL[mcli sync pull -w] -->|no script_cid| N[❌ No scripts restored]
```

**After** — one canonical lockfile, relative paths preserved, bodies + subdirs round-trip, honest IPNS status:

```mermaid
flowchart LR
    U[mcli sync update] -->|writes| C[commands.lock.json<br/>file: demo/hello.sh]
    P[mcli sync push] -->|reads| C
    P -->|uploads body| IPFS[(IPFS<br/>per-script CID)]
    P -->|publish ok?| K{IPNS}
    K -->|yes| OK[✅ Published to IPNS]
    K -->|no| WARN[⚠️ IPNS publish failed → pull by CID]
    PL[mcli sync pull -w] -->|fetch script_cid| IPFS
    PL -->|recreate demo/| R[✅ demo/hello.sh restored byte-for-byte]
```

## Validation

End-to-end against a real Kubo daemon (IPFS 0.39.0):
- `update → push → pull <CID> -w` restored `demo/hello.sh` with matching SHA-256.
- `update → push → pull -r <repo> -w` (IPNS auto-resolve, no CID) restored the same script byte-for-byte.

Native checks (run instead of the full local `act` matrix): **223 unit tests pass** across sync/loader/command suites; `black`/`isort`/`flake8` clean on changed files. 6 new regression tests added.

## Files
`script_loader.py`, `ipfs_sync.py`, `sync_cmd.py`, `paths.py`, `constants/messages.py`, tests, `docs/releases/8.0.49.md`, version bump → 8.0.49.

## Summary by Sourcery

Repair the mcli sync IPFS/IPNS round-trip so update → push → pull correctly distributes workflow scripts and reports IPNS status accurately.

Bug Fixes:
- Unify the lockfile name used by sync update, push, pull, and helpers so pushes no longer fail with missing lockfiles.
- Preserve group subdirectory paths in the lockfile and reconstruct them on pull so grouped scripts have their bodies uploaded and restored correctly.
- Ensure sync push only advertises IPNS-based teammate pulls when IPNS publish actually succeeds and otherwise warns with a pull-by-CID fallback.

Enhancements:
- Centralize lockfile path resolution on the shared FileNames.COMMANDS_LOCK_JSON constant across script loading, sync commands, and path utilities.
- Track the last published IPNS name in IPFSSync to enable accurate user-facing status messages.

Build:
- Bump project version to 8.0.49 in pyproject.toml.

Documentation:
- Add release notes for version 8.0.49 documenting the sync round-trip fixes and validation steps.

Tests:
- Add regression tests covering lockfile interoperability between update and push, grouped script round-trips through IPFS, and accurate IPNS success/failure messaging.