### PR TITLE
fix(security): prevent path traversal in IPFS workflow pull

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcli-framework"
-version = "8.0.49"
+version = "8.0.50"
 description = "Portable workflow framework - transform any script into a versioned, schedulable command. Store in ~/.mcli/workflows/, version with lockfile, run as daemon or cron job."
 readme = "README.md"
  requires-python = ">=3.10"

--- a/src/mcli/lib/ipfs_sync.py
+++ b/src/mcli/lib/ipfs_sync.py
@@ -28,7 +28,7 @@ import hashlib
 import json
 import time
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Optional
 
 import requests
@@ -535,7 +535,19 @@ class IPFSSync:
                         f"hash mismatch for '{name}': expected {expected_value}, got {actual}"
                     )
 
-            target = workflows_dir / script_filename
+            # SECURITY: `script_filename` comes from a remote, untrusted manifest.
+            # Contain it inside workflows_dir so a crafted manifest cannot write
+            # outside the directory via '..' segments or an absolute path.
+            rel = PurePosixPath(script_filename)
+            if rel.is_absolute() or any(part == ".." for part in rel.parts):
+                raise ValueError(f"unsafe script path in manifest: {script_filename}")
+            base = Path(workflows_dir).resolve()
+            target = (base / Path(*rel.parts)).resolve()
+            if base != target and base not in target.parents:
+                raise ValueError(f"script path escapes workflows dir: {script_filename}")
+
+            # Recreate group subdirectories (e.g. "demo/hello.py") on pull.
+            target.parent.mkdir(parents=True, exist_ok=True)
             target.write_bytes(payload)
             written.append(target)
 

--- a/tests/unit/test_ipfs_sync_script_bodies.py
+++ b/tests/unit/test_ipfs_sync_script_bodies.py
@@ -201,3 +201,101 @@ class TestPullWorkflowsExtractsScripts:
 
         assert written == []
         assert not (target / "hello.py").exists()
+
+
+class TestPullWorkflowsRejectsPathTraversal:
+    """A malicious manifest must not be able to write outside the workflows dir."""
+
+    @pytest.mark.parametrize(
+        "evil_name",
+        [
+            "../escape.py",
+            "../../escape.py",
+            "sub/../../escape.py",
+            "foo/../../../escape.py",
+        ],
+    )
+    def test_pull_workflows_rejects_relative_traversal(self, tmp_path, evil_name):
+        from mcli.lib.ipfs_sync import IPFSSync
+
+        target = tmp_path / "out"
+        target.mkdir()
+        outside = tmp_path / "escape.py"
+
+        manifest = {
+            "version": "2.1",
+            "commands": {
+                "evil": {
+                    "file": evil_name,
+                    "content_hash": _sha256(SAMPLE_SCRIPT),
+                    "script_cid": "QmScriptCid",
+                }
+            },
+        }
+
+        sync = IPFSSync()
+        with (
+            patch.object(sync, "pull", return_value=manifest),
+            patch.object(sync, "fetch_file_from_ipfs", return_value=SAMPLE_SCRIPT.encode()),
+        ):
+            with pytest.raises(ValueError, match="escapes|unsafe"):
+                sync.pull_workflows("QmManifestCid", target)
+
+        # nothing escaped the target directory
+        assert not outside.exists()
+
+    def test_pull_workflows_rejects_absolute_path(self, tmp_path):
+        from mcli.lib.ipfs_sync import IPFSSync
+
+        target = tmp_path / "out"
+        target.mkdir()
+        abs_target = tmp_path / "abs_escape.py"
+
+        manifest = {
+            "version": "2.1",
+            "commands": {
+                "evil": {
+                    "file": str(abs_target),  # absolute path in manifest
+                    "content_hash": _sha256(SAMPLE_SCRIPT),
+                    "script_cid": "QmScriptCid",
+                }
+            },
+        }
+
+        sync = IPFSSync()
+        with (
+            patch.object(sync, "pull", return_value=manifest),
+            patch.object(sync, "fetch_file_from_ipfs", return_value=SAMPLE_SCRIPT.encode()),
+        ):
+            with pytest.raises(ValueError, match="escapes|unsafe"):
+                sync.pull_workflows("QmManifestCid", target)
+
+        assert not abs_target.exists()
+
+    def test_pull_workflows_allows_legit_subdir(self, tmp_path):
+        """Group subdirectories like 'demo/hello.py' must still work."""
+        from mcli.lib.ipfs_sync import IPFSSync
+
+        target = tmp_path / "out"
+        target.mkdir()
+
+        manifest = {
+            "version": "2.1",
+            "commands": {
+                "hello": {
+                    "file": "demo/hello.py",
+                    "content_hash": _sha256(SAMPLE_SCRIPT),
+                    "script_cid": "QmScriptCid",
+                }
+            },
+        }
+
+        sync = IPFSSync()
+        with (
+            patch.object(sync, "pull", return_value=manifest),
+            patch.object(sync, "fetch_file_from_ipfs", return_value=SAMPLE_SCRIPT.encode()),
+        ):
+            written = sync.pull_workflows("QmManifestCid", target)
+
+        assert (target / "demo" / "hello.py").read_text() == SAMPLE_SCRIPT
+        assert written == [target / "demo" / "hello.py"]


### PR DESCRIPTION
## Summary
`IPFSSync.pull_workflows()` wrote each script to `workflows_dir / script_filename` where `script_filename` comes from a **remote, untrusted IPFS manifest**. A crafted manifest with `..` segments or an absolute path could write arbitrary files outside the workflows directory — **HIGH severity arbitrary file write** (flagged by automated security review).

## Fix
Contain the resolved target inside `workflows_dir` before writing: reject absolute paths and `..` segments, and verify the resolved path stays under the base dir. Legit group subdirectories (`demo/hello.py`) still work via a now-safe `mkdir(parents=True)`.

## Before / After
```mermaid
flowchart LR
  M[remote manifest 'file'] --> J[workflows_dir / file]
  subgraph Before
    J --> W1[write_bytes - escapes via ../..]
  end
  subgraph After
    J --> C{abs or '..'?}
    C -->|yes| X[raise ValueError]
    C -->|no| R{resolved under base?}
    R -->|no| X
    R -->|yes| W2[mkdir + write_bytes]
  end
```

## Tests
6 new (4 relative-traversal params, 1 absolute-path, 1 legit-subdir). Full sync suite (91 tests) green via `uv run pytest`.

Bumps version 8.0.49 → 8.0.50.

> Note: local `act` preflight couldn't run (Docker Hub unauthenticated pull rate limit); validated directly with `uv run pytest`.

## Summary by Sourcery

Harden IPFS workflow pulls against path traversal and validate script destinations while preserving legitimate subdirectory layouts.

Bug Fixes:
- Prevent writing workflow scripts outside the workflows directory by rejecting absolute and path-traversing script filenames from untrusted manifests.
- Ensure pulled workflow scripts are only written under the resolved workflows directory and recreate any required subdirectories safely.

Build:
- Bump project version from 8.0.49 to 8.0.50 to release the security fix.

Tests:
- Add tests covering rejection of relative path traversal, absolute paths, and acceptance of valid subdirectory workflow files in IPFS manifest pulls.