### PR TITLE
fix(ci): repair prettier pre-commit hook (deprecated mirror)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,8 +85,11 @@ repos:
   # Removed safety/pip-audit pre-commit hook as it's redundant with CI
 
   # YAML formatting
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.3.3
+  # NOTE: pre-commit/mirrors-prettier is deprecated/archived and never tagged
+  # v3.3.3 (only v4.0.0-alpha.* exist), which broke `pre-commit run`. Use the
+  # maintained successor rbubley/mirrors-prettier with a real stable tag.
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.8.3
     hooks:
       - id: prettier
         types: [yaml]


### PR DESCRIPTION
## Problem
`pre-commit/mirrors-prettier` is **archived/deprecated** and was never tagged `v3.3.3` (only `v4.0.0-alpha.*` exist). Running `pre-commit run` failed with `pathspec 'v3.3.3' did not match any file(s) known to git`, breaking the whole hook chain.

## Fix
Migrate the prettier hook to the maintained successor **`rbubley/mirrors-prettier@v3.8.3`** (stable tag).

**Before**
```yaml
- repo: https://github.com/pre-commit/mirrors-prettier   # archived, no v3.3.3 tag
  rev: v3.3.3
```
**After**
```yaml
- repo: https://github.com/rbubley/mirrors-prettier      # maintained
  rev: v3.8.3
```

## Validation
`pre-commit run prettier --files ...` → initializes rbubley mirror and **Passed**.

Closes #189.

## Summary by Sourcery

CI:
- Switch the Prettier pre-commit configuration from the deprecated `pre-commit/mirrors-prettier` repo to `rbubley/mirrors-prettier` at version v3.8.3.