### PR TITLE
fix(ci): retry docker on rate-limit; don't block push when act can't validate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcli-framework"
-version = "8.0.50"
+version = "8.0.51"
 description = "Portable workflow framework - transform any script into a versioned, schedulable command. Store in ~/.mcli/workflows/, version with lockfile, run as daemon or cron job."
 readme = "README.md"
  requires-python = ">=3.10"

--- a/src/mcli/workflow/ci/act_runner.py
+++ b/src/mcli/workflow/ci/act_runner.py
@@ -4,14 +4,34 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+import sys
+import time
 from enum import Enum
 from pathlib import Path
+
+# Docker Hub returns these when the unauthenticated image-pull rate limit is hit.
+# act surfaces them while pulling the runner image — this is an environment
+# problem, NOT a test failure, so it must not hard-block a push.
+_RATE_LIMIT_MARKERS = (
+    "toomanyrequests",
+    "you have reached your unauthenticated pull rate limit",
+    "pull rate limit",
+)
+
+# Backoff (seconds) between docker rate-limit retries; the last value repeats.
+_RETRY_BACKOFF = (15, 45)
+_MAX_RETRIES = 2
 
 
 class PreflightResult(Enum):
     PASS = "pass"
     FAIL = "fail"
     UNREACHABLE = "unreachable"
+
+
+def _is_docker_rate_limited(output: str) -> bool:
+    low = (output or "").lower()
+    return any(marker in low for marker in _RATE_LIMIT_MARKERS)
 
 
 def act_available() -> bool:
@@ -44,10 +64,50 @@ def build_act_command(event: str) -> list[str]:
     return cmd
 
 
-def run_act(event: str = "pull_request") -> PreflightResult:
-    """Run act for `event`. PASS on exit 0, else FAIL. (Probe gates UNREACHABLE upstream.)"""
-    proc = subprocess.run(build_act_command(event))
-    return PreflightResult.PASS if proc.returncode == 0 else PreflightResult.FAIL
+def run_act(
+    event: str = "pull_request",
+    retries: int = _MAX_RETRIES,
+    backoff: tuple[int, ...] = _RETRY_BACKOFF,
+) -> PreflightResult:
+    """Run act for `event` and classify the outcome.
+
+    - exit 0 -> PASS.
+    - non-zero whose output shows a Docker Hub pull rate limit
+      (``toomanyrequests``) -> retry up to ``retries`` times with backoff;
+      if still rate-limited, return UNREACHABLE (cannot validate — an
+      environment problem, not a test failure, so the gate must not block).
+    - any other non-zero exit -> FAIL.
+
+    Output is captured (to detect the rate limit) and echoed so the user still
+    sees act's progress.
+    """
+    attempt = 0
+    while True:
+        proc = subprocess.run(build_act_command(event), capture_output=True, text=True)
+        output = (proc.stdout or "") + (proc.stderr or "")
+        if output:
+            sys.stdout.write(output if output.endswith("\n") else output + "\n")
+
+        if proc.returncode == 0:
+            return PreflightResult.PASS
+
+        if _is_docker_rate_limited(output):
+            if attempt < retries:
+                delay = backoff[min(attempt, len(backoff) - 1)]
+                sys.stdout.write(
+                    f"⚠️  Docker Hub rate limit (toomanyrequests); retrying in {delay}s "
+                    f"(attempt {attempt + 1}/{retries})…\n"
+                )
+                time.sleep(delay)
+                attempt += 1
+                continue
+            sys.stdout.write(
+                "⚠️  Docker Hub still rate-limited after retries — cannot validate "
+                "locally; allowing push (run `mcli ci preflight` again later).\n"
+            )
+            return PreflightResult.UNREACHABLE
+
+        return PreflightResult.FAIL
 
 
 def preflight(repo_slug: str, event: str = "pull_request") -> PreflightResult:

--- a/src/mcli/workflow/ci/ci.py
+++ b/src/mcli/workflow/ci/ci.py
@@ -143,7 +143,18 @@ def pr():
 
 PRE_PUSH_HOOK = """#!/usr/bin/env bash
 # mcli-ci pre-push gate: validate with act before pushing.
-exec mcli ci preflight
+# Blocks ONLY on a real act failure (exit 1). When act cannot validate locally
+# — e.g. Docker Hub rate-limit (toomanyrequests, retried first), no docker, or
+# an online runner will validate instead (exit 2/3) — the push is allowed so an
+# environment hiccup never wedges your workflow. Override a real failure with:
+#   git push --no-verify
+mcli ci preflight
+code=$?
+if [ "$code" -eq 1 ]; then
+  echo "mcli-ci: act reported failures — push blocked. Override: git push --no-verify" >&2
+  exit 1
+fi
+exit 0
 """
 
 

--- a/tests/unit/workflow/test_ci_act_runner.py
+++ b/tests/unit/workflow/test_ci_act_runner.py
@@ -57,6 +57,39 @@ class TestRunAct:
             assert run_act("pull_request") == PreflightResult.FAIL
 
 
+class TestRunActDockerRateLimit:
+    """Docker Hub rate limits are retried, then treated as cannot-validate."""
+
+    _RL = (
+        "Error response from daemon: toomanyrequests: You have reached your "
+        "unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit"
+    )
+
+    def test_rate_limit_exhausted_is_unreachable(self):
+        # every attempt hits the rate limit -> UNREACHABLE (not FAIL), so the gate
+        # does not block the push.
+        with patch("subprocess.run", return_value=_cp(1, stdout=self._RL)) as m, patch(
+            "time.sleep"
+        ):
+            assert (
+                run_act("pull_request", retries=2, backoff=(0, 0))
+                == PreflightResult.UNREACHABLE
+            )
+        assert m.call_count == 3  # initial + 2 retries
+
+    def test_rate_limit_then_success_on_retry(self):
+        seq = [_cp(1, stdout=self._RL), _cp(0)]
+        with patch("subprocess.run", side_effect=seq), patch("time.sleep"):
+            assert run_act("pull_request", retries=2, backoff=(0, 0)) == PreflightResult.PASS
+
+    def test_real_failure_is_not_retried(self):
+        with patch(
+            "subprocess.run", return_value=_cp(1, stdout="3 tests failed")
+        ) as m, patch("time.sleep"):
+            assert run_act("pull_request") == PreflightResult.FAIL
+        assert m.call_count == 1
+
+
 from mcli.workflow.ci.act_runner import preflight
 
 

--- a/tests/unit/workflow/test_ci_cli.py
+++ b/tests/unit/workflow/test_ci_cli.py
@@ -105,6 +105,24 @@ class TestDoctorAndHook:
         assert "mcli ci preflight" in hook.read_text()
         assert hook.stat().st_mode & 0o111  # executable
 
+    def test_pre_push_hook_blocks_only_on_real_failure(self, tmp_path, monkeypatch):
+        """Hook blocks on preflight exit 1, allows exit 0/2/3 (cannot-validate)."""
+        import subprocess as sp
+        from mcli.workflow.ci.ci import PRE_PUSH_HOOK
+
+        hook = tmp_path / "pre-push"
+        hook.write_text(PRE_PUSH_HOOK)
+        for code, should_block in [(0, False), (1, True), (2, False), (3, False)]:
+            # stub `mcli` on PATH that just exits with `code`
+            stub_dir = tmp_path / f"bin{code}"
+            stub_dir.mkdir()
+            (stub_dir / "mcli").write_text(f"#!/usr/bin/env bash\nexit {code}\n")
+            (stub_dir / "mcli").chmod(0o755)
+            env = {"PATH": f"{stub_dir}:/usr/bin:/bin"}
+            res = sp.run(["bash", str(hook)], env=env, capture_output=True, text=True)
+            blocked = res.returncode != 0
+            assert blocked is should_block, f"code={code} expected block={should_block}"
+
 
 from mcli.workflow.ci import ci as ci_mod
 


### PR DESCRIPTION
## Problem
The `mcli ci` pre-push gate hard-failed (blocked the push) when `act` couldn't pull its runner image because of Docker Hub's **unauthenticated pull rate limit** (`toomanyrequests`). That's an environment problem, not a test failure — it shouldn't wedge pushes. (Hit this firsthand pushing a security fix earlier.)

## Fix
1. **`run_act()`** captures act output, detects the docker rate limit, **retries with backoff** (2×: 15s, 45s). A persistent rate limit is classified **UNREACHABLE** (cannot validate) — not FAIL.
2. **Pre-push hook** now blocks **only on a real act failure (exit 1)**. On cannot-validate / online-runner (exit 2/3) it warns and **allows the push** — the `--no-verify` effect — so a docker hiccup never blocks work. Real failures still block (override with `git push --no-verify`).

## Before / After
```mermaid
flowchart LR
  A[act run] --> R{exit 0?}
  R -->|yes| P[PASS]
  R -->|no| L{docker toomanyrequests?}
  subgraph Before
    L -->|n/a| F1[FAIL -> push BLOCKED]
  end
  subgraph After
    L -->|yes| RT{retries left?}
    RT -->|yes| A
    RT -->|no| U[UNREACHABLE -> push ALLOWED]
    L -->|no| F2[FAIL -> push BLOCKED]
  end
```

## Tests
rate-limit-exhausted→UNREACHABLE (asserts retry count), rate-limit-then-pass, real-failure-not-retried, hook blocks only on exit 1. 31 ci tests green. Bumps 8.0.50 → 8.0.51.

## Summary by Sourcery

Handle Docker Hub rate-limit errors in local CI runs without blocking pushes and adjust the pre-push gate behavior accordingly.

Bug Fixes:
- Treat Docker Hub unauthenticated pull rate limit errors from act as an unreachable environment condition with limited retries instead of a hard CI failure.
- Allow the mcli CI pre-push hook to proceed when act cannot validate locally, only blocking on genuine act failures.

Enhancements:
- Echo captured act output while adding retry and classification logic for non-zero exits in the act runner.

Build:
- Bump mcli-framework version from 8.0.50 to 8.0.51.

Tests:
- Add unit coverage for Docker rate-limit handling, retry behavior, and the pre-push hook exit-code semantics in the CI workflow.