### PR TITLE
fix(sync): stop dropping scripts with colliding stems

### DIFF
--- a/docs/releases/8.0.53.md
+++ b/docs/releases/8.0.53.md
@@ -1,0 +1,114 @@
+# Release Notes - Version 8.0.53
+
+**Release Date:** 2026-06-01
+
+## Overview
+
+Version 8.0.53 fixes a **stem-collision data-loss bug** in `mcli sync`: scripts
+sharing a base name (e.g. `commit.py` and `commit.sh`, or the same name in
+different group subdirectories) were silently dropped from the lockfile, so
+`mcli sync now`/`push` never transported them. On a real workflows directory
+this dropped **32 of 119 scripts**.
+
+## The Bug
+
+`ScriptLoader.generate_lockfile()` keyed every command by its bare
+`script_path.stem`:
+
+```python
+for script_path in scripts:
+    name = script_path.stem          # "commit" for BOTH commit.py and commit.sh
+    lockfile_data["commands"][name] = info   # second one overwrites the first
+```
+
+So two scripts with the same stem collapsed to a single lockfile entry — the
+later silently clobbered the earlier. The `name:lang` disambiguation added in
+v8.0.38 (`docs/features/LANGUAGE_SUFFIX.md`) was applied by `mcli list` / `mcli
+run` at runtime, but **never by the lockfile**, so sync still lost the shadowed
+scripts.
+
+## The Fix
+
+A single source of truth, `ScriptLoader._assign_command_keys()`, assigns every
+discovered script a **unique** key using the existing convention:
+
+- unique stem            → bare `stem` (`deploy`)
+- stem collision         → `stem:lang` (`commit:py`, `commit:sh`)
+- stem **and** lang both collide across dirs → `stem:lang:<dir-slug>` (and a
+  final numeric guard) so identically named/typed scripts in different
+  directories are each preserved.
+
+Every lockfile-key consumer now derives its key from the same function, so
+producer and verifier cannot drift:
+
+- `generate_lockfile()` — writes one entry per script (no more drops).
+- `verify_lockfile()` — maps disk scripts by canonical key (no false
+  missing/extra in `sync diff`/`status`).
+- `sync status` / `sync diff` (`sync_cmd.py`) — look up by canonical key and
+  display the disambiguated name, matching `mcli list`.
+
+**Unchanged (verified safe):** `mcli run` and `mcli list` resolve from live
+filesystem discovery, not lockfile keys; `sync pull` reconstructs files from
+each entry's `file` (relative path), not the key. So the round-trip and runtime
+invocation are unaffected by the key-scheme change.
+
+## Before / After
+
+**Before** — colliding stems collapse; the shadowed script is lost before push:
+
+```mermaid
+flowchart LR
+    A[commit.py] --> K[key = stem = 'commit']
+    B[commit.sh] --> K
+    K --> L[lockfile['commit']<br/>= commit.sh only]
+    A -. overwritten .-> X[❌ commit.py dropped]
+    L --> P[push: 1 of 2 synced]
+```
+
+**After** — each script gets a distinct key; both sync:
+
+```mermaid
+flowchart LR
+    A[commit.py] --> KA[commit:py]
+    B[commit.sh] --> KB[commit:sh]
+    KA --> L[lockfile]
+    KB --> L
+    L --> P[push: 2 of 2 synced]
+    P --> PU[pull -w → both restored byte-for-byte]
+```
+
+## Validation
+
+- Engine: on a real 119-script workflows dir, `_assign_command_keys` now yields
+  **119 unique keys** (was collapsing to 87 — recovers all 32 dropped), 63
+  disambiguated.
+- End-to-end CLI: `update → push → pull -w` of a `commit.py`/`commit.sh` pair
+  restores **both** byte-for-byte; `sync status` shows both `synced`,
+  `sync diff` reports in-sync.
+- 6 new regression tests in `tests/unit/test_script_loader_stem_collision.py`;
+  full `test_language_suffix` + sync suites green (189 tests).
+
+## Files Changed
+
+- `src/mcli/lib/script_loader.py` — `_assign_command_keys`, `generate_lockfile`, `verify_lockfile`
+- `src/mcli/app/sync_cmd.py` — `sync status` / `sync diff` key by canonical key
+- `tests/unit/test_script_loader_stem_collision.py` — new
+
+## Upgrade Guide
+
+No breaking changes. Update, then re-run `mcli sync update` once to regenerate
+the lockfile with all scripts tracked:
+
+```bash
+uv tool install mcli-framework --force
+mcli sync update
+```
+
+Colliding commands now appear as `name:lang` (e.g. `commit:py`) in `mcli list`,
+`mcli sync status`, and the lockfile — invoke them with `mcli run commit:py`.
+
+## Links
+
+- **PyPI**: https://pypi.org/project/mcli-framework/8.0.53/
+- **GitHub Release**: https://github.com/gwicho38/mcli/releases/tag/v8.0.53
+- **Full Changelog**: https://github.com/gwicho38/mcli/compare/v8.0.52...v8.0.53

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcli-framework"
-version = "8.0.52"
+version = "8.0.53"
 description = "Portable workflow framework - transform any script into a versioned, schedulable command. Store in ~/.mcli/workflows/, version with lockfile, run as daemon or cron job."
 readme = "README.md"
  requires-python = ">=3.10"

--- a/src/mcli/app/sync_cmd.py
+++ b/src/mcli/app/sync_cmd.py
@@ -213,8 +213,12 @@ def sync_status(is_global: bool):
     table.add_column("Hash", style="dim")
     table.add_column("Status", style="yellow")
 
+    # Key scripts the same way the lockfile does, so colliding stems
+    # (commit.py/commit.sh) match their entries instead of showing "unlocked".
+    command_keys = loader._assign_command_keys(scripts)
+
     for script_path in scripts:
-        name = script_path.stem
+        name = command_keys[script_path]
         script_info = loader.get_script_info(script_path)
 
         # Check status against lockfile
@@ -331,8 +335,10 @@ def sync_diff(is_global: bool):
         for name in verification["hash_mismatch"]:
             if name in locked_commands:
                 old_version = locked_commands[name].get("version", "?")
-                # Get current version
-                scripts = {p.stem: p for p in loader.discover_scripts()}
+                # Get current version. verify_lockfile() reports canonical keys
+                # (name:lang on collision), so map disk scripts the same way.
+                discovered = loader.discover_scripts()
+                scripts = {k: p for p, k in loader._assign_command_keys(discovered).items()}
                 if name in scripts:
                     script_info = loader.get_script_info(scripts[name])
                     new_version = script_info.get("version", "?")

--- a/src/mcli/lib/script_loader.py
+++ b/src/mcli/lib/script_loader.py
@@ -860,12 +860,70 @@ class ScriptLoader:
             "commands": {},
         }
 
+        keys = self._assign_command_keys(scripts)
         for script_path in scripts:
-            name = script_path.stem
             info = self.get_script_info(script_path)
-            lockfile_data["commands"][name] = info
+            lockfile_data["commands"][keys[script_path]] = info
 
         return lockfile_data
+
+    def _assign_command_keys(self, scripts: list[Path]) -> dict[Path, str]:
+        """Assign a unique lockfile/command key to every discovered script.
+
+        Without this, scripts were keyed by bare ``stem`` and any two sharing a
+        stem (``commit.py`` + ``commit.sh``, or the same name in different group
+        subdirectories) collapsed to one entry — the later silently overwrote
+        the earlier, so ``mcli sync`` dropped the shadowed script entirely.
+
+        Keys follow the ``name:lang`` disambiguation convention already used by
+        ``mcli list`` / ``mcli run`` (see docs/features/LANGUAGE_SUFFIX.md):
+
+        - unique stem            -> bare ``stem``
+        - stem collision         -> ``stem:lang`` (e.g. ``commit:py``)
+        - stem+lang both collide -> ``stem:lang:<dir-slug>`` so identically
+          named/typed scripts in different directories are each preserved
+          (deterministic, derived from the relative parent path).
+        """
+        from collections import Counter
+
+        stem_counts = Counter(p.stem for p in scripts)
+
+        # First pass: bare stem when unique, else stem:lang.
+        provisional: dict[Path, str] = {}
+        for p in scripts:
+            if stem_counts[p.stem] > 1:
+                suffix = LANGUAGE_TO_SUFFIX.get(self.detect_language(p), "x")
+                provisional[p] = f"{p.stem}:{suffix}"
+            else:
+                provisional[p] = p.stem
+
+        # Second pass: resolve any residual collisions (same stem+lang across
+        # different directories) using a stable slug from the relative parent.
+        key_counts = Counter(provisional.values())
+        keys: dict[Path, str] = {}
+        for p in scripts:
+            key = provisional[p]
+            if key_counts[key] > 1:
+                try:
+                    parent = p.relative_to(self.workflows_dir).parent.as_posix()
+                except ValueError:
+                    parent = p.parent.name
+                slug = parent.strip("/").replace("/", "-") or "root"
+                key = f"{key}:{slug}"
+            keys[p] = key
+
+        # Final guard: never emit duplicate keys. If two scripts still map to the
+        # same key (pathological), append a deterministic numeric suffix instead
+        # of silently dropping one.
+        seen: dict[str, int] = {}
+        for p in sorted(scripts, key=lambda x: x.as_posix()):
+            base = keys[p]
+            if base in seen:
+                seen[base] += 1
+                keys[p] = f"{base}:{seen[base]}"
+            else:
+                seen[base] = 0
+        return keys
 
     def save_lockfile(self) -> bool:
         """
@@ -939,7 +997,11 @@ class ScriptLoader:
             return result
 
         locked_commands = lockfile.get("commands", {})
-        current_scripts = {p.stem: p for p in self.discover_scripts()}
+        # Key disk scripts with the SAME disambiguation scheme used to write the
+        # lockfile, otherwise colliding stems (commit.py/commit.sh) would be
+        # reported as false missing/extra drift.
+        discovered = self.discover_scripts()
+        current_scripts = {key: p for p, key in self._assign_command_keys(discovered).items()}
 
         # Check for missing scripts (in lockfile but not on disk)
         for name in locked_commands:

--- a/tests/unit/test_script_loader_stem_collision.py
+++ b/tests/unit/test_script_loader_stem_collision.py
@@ -1,0 +1,134 @@
+"""Regression tests for stem-collision handling in the lockfile.
+
+Bug: `generate_lockfile` keyed commands by bare ``script_path.stem``, so two
+scripts sharing a stem (e.g. ``commit.py`` and ``commit.sh``, or the same name
+in different group subdirectories) collapsed to a single lockfile entry — the
+later one silently overwrote the earlier. `mcli sync now` therefore dropped
+every colliding script before push.
+
+The lockfile must give every discovered script a distinct entry, using the
+``name:lang`` disambiguation convention already used by ``mcli list``/``run``
+(see docs/features/LANGUAGE_SUFFIX.md).
+"""
+
+import json
+from pathlib import Path
+
+from mcli.lib.script_loader import ScriptLoader
+
+PY = "#!/usr/bin/env python3\n# @description: py impl\nprint('py')\n"
+SH = "#!/usr/bin/env bash\n# @description: sh impl\necho sh\n"
+
+
+def _commands(loader: ScriptLoader) -> dict:
+    assert loader.save_lockfile() is True
+    return json.loads(loader.lockfile_path.read_text())["commands"]
+
+
+def test_cross_language_collision_keeps_both(tmp_path):
+    """commit.py and commit.sh must both survive, suffixed by language."""
+    wd = tmp_path / "workflows"
+    (wd / "dotfiles").mkdir(parents=True)
+    (wd / "dotfiles" / "commit.py").write_text(PY)
+    (wd / "dotfiles" / "commit.sh").write_text(SH)
+
+    cmds = _commands(ScriptLoader(wd))
+
+    # Both implementations are tracked under distinct, language-suffixed keys.
+    assert "commit:py" in cmds, cmds.keys()
+    assert "commit:sh" in cmds, cmds.keys()
+    assert cmds["commit:py"]["file"] == "dotfiles/commit.py"
+    assert cmds["commit:sh"]["file"] == "dotfiles/commit.sh"
+    # No bare 'commit' that silently shadows one of them.
+    assert "commit" not in cmds
+
+
+def test_unique_stem_stays_bare(tmp_path):
+    """A stem with no collision keeps its bare name for ergonomics."""
+    wd = tmp_path / "workflows"
+    wd.mkdir()
+    (wd / "deploy.py").write_text(PY)
+
+    cmds = _commands(ScriptLoader(wd))
+    assert "deploy" in cmds
+    assert cmds["deploy"]["file"] == "deploy.py"
+
+
+def test_same_name_same_ext_different_dirs_not_dropped(tmp_path):
+    """Two scripts with identical name AND extension in different dirs must
+    each get a distinct entry — neither may be silently dropped."""
+    wd = tmp_path / "workflows"
+    (wd / "a").mkdir(parents=True)
+    (wd / "b").mkdir(parents=True)
+    (wd / "a" / "videos.py").write_text(PY)
+    (wd / "b" / "videos.py").write_text(SH.replace("echo sh", "print('b')"))
+
+    cmds = _commands(ScriptLoader(wd))
+
+    # Every distinct file is represented exactly once.
+    files = sorted(v["file"] for v in cmds.values())
+    assert files == ["a/videos.py", "b/videos.py"], files
+    assert len(cmds) == 2, cmds.keys()
+
+
+def test_no_script_dropped_overall(tmp_path):
+    """Total lockfile entries == number of discovered script files."""
+    wd = tmp_path / "workflows"
+    (wd / "g1").mkdir(parents=True)
+    (wd / "g2").mkdir(parents=True)
+    (wd / "g1" / "build.py").write_text(PY)
+    (wd / "g1" / "build.sh").write_text(SH)
+    (wd / "g2" / "build.py").write_text(PY)  # collides with g1/build.py on name+ext
+    (wd / "solo.sh").write_text(SH)
+
+    loader = ScriptLoader(wd)
+    n_files = len(loader.discover_scripts())
+    cmds = _commands(loader)
+    assert len(cmds) == n_files == 4, (len(cmds), n_files, list(cmds.keys()))
+
+
+def test_verify_lockfile_clean_after_save_with_collisions(tmp_path):
+    """`sync diff`/`status` (verify_lockfile) must not report false drift when
+    colliding scripts are tracked under name:lang keys."""
+    wd = tmp_path / "workflows"
+    (wd / "dotfiles").mkdir(parents=True)
+    (wd / "dotfiles" / "commit.py").write_text(PY)
+    (wd / "dotfiles" / "commit.sh").write_text(SH)
+    (wd / "deploy.py").write_text(PY)
+
+    loader = ScriptLoader(wd)
+    assert loader.save_lockfile() is True
+
+    result = loader.verify_lockfile()
+    assert result["missing"] == [], result["missing"]
+    assert result["extra"] == [], result["extra"]
+    assert result["hash_mismatch"] == [], result["hash_mismatch"]
+    assert result["valid"] is True
+
+
+def test_sync_status_shows_collided_scripts_as_synced(tmp_path):
+    """`mcli sync status` must mark colliding scripts synced (not 'unlocked')
+    and display their disambiguated names."""
+    from unittest.mock import patch
+
+    from click.testing import CliRunner
+
+    from mcli.app.sync_cmd import sync_group
+
+    wd = tmp_path / "workflows"
+    (wd / "dotfiles").mkdir(parents=True)
+    (wd / "dotfiles" / "commit.py").write_text(PY)
+    (wd / "dotfiles" / "commit.sh").write_text(SH)
+
+    runner = CliRunner()
+    with patch("mcli.app.sync_cmd.get_custom_commands_dir", return_value=wd):
+        assert runner.invoke(sync_group, ["update"]).exit_code == 0
+        result = runner.invoke(sync_group, ["status"])
+        diff = runner.invoke(sync_group, ["diff"])
+
+    assert result.exit_code == 0, result.output
+    assert "unlocked" not in result.output, result.output
+    assert "commit:py" in result.output and "commit:sh" in result.output, result.output
+    # diff right after update => in sync, no spurious added/removed.
+    assert "Added scripts" not in diff.output, diff.output
+    assert "Removed scripts" not in diff.output, diff.output


### PR DESCRIPTION
## Summary

Fixes a **stem-collision data-loss bug** in `mcli sync`. Found while verifying a real `mcli sync now` (user reported 119 scripts discovered but only 87 synced).

`generate_lockfile` keyed every command by bare `script_path.stem`, so two scripts sharing a stem — `commit.py` + `commit.sh`, or the same name in different group subdirs — collapsed to one lockfile entry; the later silently overwrote the earlier. **32 of 119 scripts were dropped before push.**

The `name:lang` disambiguation from v8.0.38 (`LANGUAGE_SUFFIX.md`) was applied by `mcli list`/`run` at runtime but **never by the lockfile**.

## Fix

`ScriptLoader._assign_command_keys()` — single source of truth, unique key per script:
- unique stem → `stem`
- collision → `stem:lang` (`commit:py`, `commit:sh`)
- stem+lang collide across dirs → `stem:lang:<dir>` (+ numeric guard)

Routed `generate_lockfile`, `verify_lockfile`, and `sync status`/`diff` through it (producer/verifier can't drift). **Unchanged & verified safe:** `mcli run`/`list` resolve via live discovery; `sync pull` reconstructs by `entry['file']` — confirmed by a parallel blast-radius trace of every key consumer.

## Before / After

**Before**
```mermaid
flowchart LR
    A[commit.py] --> K[key='commit']
    B[commit.sh] --> K
    K --> L[lockfile only commit.sh]
    A -. overwritten .-> X[❌ commit.py dropped]
```
**After**
```mermaid
flowchart LR
    A[commit.py] --> KA[commit:py]
    B[commit.sh] --> KB[commit:sh]
    KA --> L[lockfile]
    KB --> L
    L --> P[push 2/2 → pull restores both]
```

## Validation

- Real 119-script dir: `_assign_command_keys` → **119 unique keys** (was 87; recovers all 32).
- CLI `update→push→pull -w` of `commit.py`/`commit.sh`: **both restored byte-for-byte**; `status` shows both `synced`, `diff` in-sync.
- 6 new regression tests; 189 tests green across sync + `test_language_suffix` suites. flake8/black clean.

Version → 8.0.53.

## Summary by Sourcery

Fix stem-based key collisions in script discovery so all scripts are uniquely tracked in the lockfile and sync flows.

Bug Fixes:
- Ensure scripts with colliding names (across languages or directories) each receive a distinct lockfile key to prevent silent drops during sync.
- Align lockfile verification and sync status/diff with the canonical command key scheme to avoid false missing/extra reports for colliding scripts.

Enhancements:
- Introduce a single canonical key-assignment helper for scripts and reuse it across lockfile generation, verification, and sync commands for consistent behavior.

Build:
- Bump project version to 8.0.53.

Documentation:
- Add release notes for version 8.0.53 documenting the stem-collision bug, its impact, and the fix.

Tests:
- Add regression test coverage for stem-collision handling in lockfile generation, verification, and sync status/diff output.