### PR TITLE
fix(commands): skip stale workflows.lock.json in legacy loader

### DIFF
--- a/docs/releases/8.0.54.md
+++ b/docs/releases/8.0.54.md
@@ -1,0 +1,79 @@
+# Release Notes - Version 8.0.54
+
+**Release Date:** 2026-06-01
+
+## Overview
+
+Version 8.0.54 silences a spurious error logged on **every** `mcli` invocation
+for anyone who used sync before v8.0.49:
+
+```
+[ERROR] Command data missing 'name' key: ['version', 'generated_at', 'commands']
+```
+
+## The Bug
+
+The v8.0.49 lockfile rename (`workflows.lock.json` → `commands.lock.json`) left
+the old `workflows.lock.json` behind in users' command directories. The legacy
+JSON-command loader (`CustomCommandManager.load_all_commands`) skipped only
+`commands.lock.json`, so the stale `workflows.lock.json` was loaded as if it
+were a command and failed the `name`-key check — logging an ERROR on startup.
+It was cosmetic (the app continued), but noisy and alarming.
+
+## The Fix
+
+Introduced a single `LOCKFILE_NAMES` set (backed by new
+`FileNames.WORKFLOWS_LOCK_JSON` / `FileNames.SYNC_CACHE_JSON` constants) and use
+it everywhere the commands directory is scanned, so **all** lockfile/cache files
+are skipped — current and legacy:
+
+- `CustomCommandManager.load_all_commands` (the loader that logged the error)
+- `has_custom_commands` (replaces a duplicated literal tuple)
+
+## Before / After
+
+```mermaid
+flowchart LR
+    subgraph Before
+      D[commands dir] --> S1{skip == commands.lock.json?}
+      S1 -->|commands.lock.json| OK1[skipped]
+      S1 -->|workflows.lock.json| L[loaded as command]
+      L --> E[❌ ERROR missing 'name']
+    end
+    subgraph After
+      D2[commands dir] --> S2{name in LOCKFILE_NAMES?}
+      S2 -->|any lockfile/cache| OK2[skipped cleanly]
+      S2 -->|real command| R[loaded]
+    end
+```
+
+## Validation
+
+- Against a real dir containing a stale `workflows.lock.json`: the installed
+  loader leaks 1 lockfile-shaped entry (the error); the fixed loader leaks 0.
+- New regression tests in `tests/unit/test_custom_commands_skip_lockfiles.py`;
+  `test_custom_commands*` suites green.
+
+## Upgrade Guide
+
+No breaking changes:
+
+```bash
+uv tool install mcli-framework --force
+```
+
+A stale `workflows.lock.json` in `~/.mcli/workflows/` (or a repo's
+`.mcli/commands/`) is now ignored. It is safe to delete — the active lockfile is
+`commands.lock.json`.
+
+## Files Changed
+
+- `src/mcli/lib/custom_commands.py` — `LOCKFILE_NAMES`; skip all lockfiles
+- `src/mcli/lib/constants/paths.py` — `WORKFLOWS_LOCK_JSON`, `SYNC_CACHE_JSON`
+- `tests/unit/test_custom_commands_skip_lockfiles.py` — new
+
+## Links
+
+- **PyPI**: https://pypi.org/project/mcli-framework/8.0.54/
+- **GitHub Release**: https://github.com/gwicho38/mcli/releases/tag/v8.0.54
+- **Full Changelog**: https://github.com/gwicho38/mcli/compare/v8.0.53...v8.0.54

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcli-framework"
-version = "8.0.53"
+version = "8.0.54"
 description = "Portable workflow framework - transform any script into a versioned, schedulable command. Store in ~/.mcli/workflows/, version with lockfile, run as daemon or cron job."
 readme = "README.md"
  requires-python = ">=3.10"

--- a/src/mcli/lib/constants/paths.py
+++ b/src/mcli/lib/constants/paths.py
@@ -51,6 +51,10 @@ class FileNames:
     GITIGNORE = ".gitignore"
     STORE_CONF = "store.conf"
     COMMANDS_LOCK_JSON = "commands.lock.json"
+    # Legacy lockfile name (pre-v8.0.49); still skipped by loaders so a stale
+    # straggler is never parsed as a command.
+    WORKFLOWS_LOCK_JSON = "workflows.lock.json"
+    SYNC_CACHE_JSON = ".sync_cache.json"
     LSH_ENV = "lsh.env"
     README_MD = "README.md"
     ENV = ".env"

--- a/src/mcli/lib/custom_commands.py
+++ b/src/mcli/lib/custom_commands.py
@@ -28,6 +28,7 @@ from typing import Any, Optional, Union
 
 import click
 
+from mcli.lib.constants import FileNames
 from mcli.lib.logger.logger import get_logger, register_subprocess
 from mcli.lib.paths import (
     get_custom_commands_dir,
@@ -37,6 +38,17 @@ from mcli.lib.paths import (
 )
 
 logger = get_logger()
+
+# Lockfile / cache filenames that live in the commands dir but are NOT
+# legacy JSON commands. Loaders must skip all of these so a stale straggler
+# (e.g. a pre-v8.0.49 workflows.lock.json) is never parsed as a command.
+LOCKFILE_NAMES = frozenset(
+    {
+        FileNames.COMMANDS_LOCK_JSON,
+        FileNames.WORKFLOWS_LOCK_JSON,
+        FileNames.SYNC_CACHE_JSON,
+    }
+)
 
 
 class CustomCommandManager:
@@ -178,8 +190,9 @@ class CustomCommandManager:
             if command_file.name.startswith("."):
                 continue
 
-            # Skip the lockfile
-            if command_file.name == "commands.lock.json":
+            # Skip lockfiles / sync cache (incl. stale pre-v8.0.49
+            # workflows.lock.json) so they are never parsed as commands.
+            if command_file.name in LOCKFILE_NAMES:
                 continue
 
             # Skip test commands unless explicitly included
@@ -681,7 +694,7 @@ def has_legacy_json_commands(global_mode: bool = False) -> bool:
 
     for json_file in commands_dir.glob("*.json"):
         # Skip lockfiles
-        if json_file.name in ("commands.lock.json", "workflows.lock.json", ".sync_cache.json"):
+        if json_file.name in LOCKFILE_NAMES:
             continue
         return True
     return False

--- a/tests/unit/test_custom_commands_skip_lockfiles.py
+++ b/tests/unit/test_custom_commands_skip_lockfiles.py
@@ -1,0 +1,65 @@
+"""Regression: the legacy JSON command loader must skip ALL lockfiles.
+
+Bug: `CustomCommandManager.load_all_commands` skipped only
+``commands.lock.json``. A stale ``workflows.lock.json`` (left behind by the
+v8.0.49 lockfile rename) was then loaded as if it were a legacy command,
+producing ``ERROR Command data missing 'name' key: ['version',
+'generated_at', 'commands']`` on every mcli invocation.
+"""
+
+import json
+from unittest.mock import patch
+
+from mcli.lib.custom_commands import CustomCommandManager
+
+LOCKFILE_BODY = {
+    "version": "2.0",
+    "generated_at": "2026-06-01T00:00:00Z",
+    "commands": {"foo": {"file": "foo.py"}},
+}
+VALID_CMD = {
+    "name": "real_cmd",
+    "code": "print('hi')",
+    "language": "python",
+    "description": "a real command",
+}
+
+
+def _manager(tmp_path):
+    cmds = tmp_path / "commands"
+    cmds.mkdir()
+    with (
+        patch("mcli.lib.custom_commands.get_custom_commands_dir", return_value=cmds),
+        patch(
+            "mcli.lib.custom_commands.get_lockfile_path", return_value=cmds / "commands.lock.json"
+        ),
+    ):
+        return CustomCommandManager(global_mode=True), cmds
+
+
+def test_load_all_commands_skips_workflows_lockfile(tmp_path):
+    mgr, cmds = _manager(tmp_path)
+    (cmds / "workflows.lock.json").write_text(json.dumps(LOCKFILE_BODY))
+    (cmds / "commands.lock.json").write_text(json.dumps(LOCKFILE_BODY))
+    (cmds / "real_cmd.json").write_text(json.dumps(VALID_CMD))
+
+    loaded = mgr.load_all_commands()
+
+    names = [c.get("name") for c in loaded]
+    # Only the genuine command is loaded; neither lockfile leaks in.
+    assert names == ["real_cmd"], names
+    # No lockfile-shaped dict (version/generated_at/commands) sneaks through.
+    assert all("generated_at" not in c for c in loaded), loaded
+
+
+def test_legacy_loader_does_not_error_on_stale_lockfile(tmp_path, caplog):
+    """No 'missing name key' ERROR should be logged for the stale lockfile."""
+    import logging
+
+    mgr, cmds = _manager(tmp_path)
+    (cmds / "workflows.lock.json").write_text(json.dumps(LOCKFILE_BODY))
+
+    with caplog.at_level(logging.ERROR):
+        mgr.load_all_commands()
+
+    assert "missing 'name' key" not in caplog.text, caplog.text


### PR DESCRIPTION
## Summary

Silences a spurious `[ERROR] Command data missing 'name' key: ['version', 'generated_at', 'commands']` logged on **every** `mcli` invocation. Surfaced from a user's real `mcli sync now` run.

**Cause:** the v8.0.49 lockfile rename (`workflows.lock.json` → `commands.lock.json`) left the old file behind. `CustomCommandManager.load_all_commands` skipped only `commands.lock.json`, so the stale `workflows.lock.json` was parsed as a legacy command and failed the name-key check.

**Fix:** one `LOCKFILE_NAMES` set (new `FileNames.WORKFLOWS_LOCK_JSON`/`SYNC_CACHE_JSON` constants), used at both commands-dir scan sites — all lockfile/cache files skipped, current and legacy.

## Before / After

```mermaid
flowchart LR
    subgraph Before
      S1{skip == commands.lock.json?} -->|workflows.lock.json| L[loaded as command]
      L --> E[❌ ERROR missing 'name']
    end
    subgraph After
      S2{name in LOCKFILE_NAMES?} -->|any lockfile| OK[skipped cleanly]
    end
```

## Validation

- Real dir with stale `workflows.lock.json`: installed loader leaks 1 lockfile-shaped entry (the error); fixed loader leaks 0.
- New regression tests; `test_custom_commands*` green. flake8/black clean.

Version → 8.0.54.

## Summary by Sourcery

Skip legacy and cache lockfiles when loading custom JSON commands to prevent stale workflow lockfiles from being treated as commands.

Bug Fixes:
- Ensure stale workflows.lock.json and other lock/cache files are ignored by custom command loading and legacy command detection, eliminating spurious 'missing name' errors on startup.

Enhancements:
- Centralize lockfile and cache filenames into shared constants and a single LOCKFILE_NAMES set reused across command directory scans.

Build:
- Bump mcli-framework version from 8.0.53 to 8.0.54.

Documentation:
- Add release notes for version 8.0.54 describing the lockfile handling fix and upgrade guidance.

Tests:
- Add regression tests verifying that all lockfiles are skipped by the legacy JSON command loader and no erroneous errors are logged when stale lockfiles are present.