### PR TITLE
fix: backlog decisions — strict CI deps (#169) + model_cmd tests (#178)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install maturin
         pip install -e .[dev]
+        # Self-hosted runner: pip falls back to --user installs, whose console
+        # scripts (maturin, mcli, pytest) land in user-base/bin, not on PATH.
+        echo "$(python -m site --user-base)/bin" >> "$GITHUB_PATH"
 
     - name: Build Rust extensions
       run: |
@@ -141,7 +144,7 @@ jobs:
 
     - name: Run Python tests with coverage
       run: |
-        pytest tests/ -v --tb=short --cov=src/mcli --cov-report=xml --cov-report=term-missing
+        python -m pytest tests/ -v --tb=short --cov=src/mcli --cov-report=xml --cov-report=term-missing
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
@@ -259,6 +262,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build maturin
+        # Ensure --user console scripts (maturin) are on PATH on self-hosted runner
+        echo "$(python -m site --user-base)/bin" >> "$GITHUB_PATH"
 
     - name: Build Rust extensions
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,9 +157,11 @@ jobs:
 
     - name: Test CLI functionality
       run: |
-        mcli self version
-        mcli --help
-        mcli self --help
+        # python -m: editable-install console script may not be on PATH on the
+        # self-hosted runner (pip --user fallback), but the module always is.
+        python -m mcli self version
+        python -m mcli --help
+        python -m mcli self --help
 
   integration-test:
     name: Integration Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
   test-python:
     name: Test Python Package
     runs-on: [self-hosted, linux, x64]
-    continue-on-error: true  # Some tests require optional deps (pandas, pydot) not in [dev]
+    # pandas/pydot are now in [dev], so this job gates on real failures (#169).
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,24 +30,24 @@ jobs:
         pip install -e .[dev]
 
     - name: Check code formatting with Black
-      run: black --check --diff src/
+      run: python -m black --check --diff src/
 
     - name: Check import sorting with isort
-      run: isort --check-only --diff src/
+      run: python -m isort --check-only --diff src/
 
     - name: Check for hardcoded strings
       run: python tools/lint_hardcoded_strings.py --check-all --json
       continue-on-error: true  # Non-blocking until codebase refactoring is complete (13k+ violations)
 
     - name: Type checking with mypy (full codebase)
-      run: mypy src/ --ignore-missing-imports
+      run: python -m mypy src/ --ignore-missing-imports
       continue-on-error: true  # Non-blocking due to type errors in remaining modules
 
     - name: Type checking with mypy (priority modules)
       run: |
         # Check priority modules that have improved type annotations (issue #40)
         # These modules have fewer errors and are gradually being fully typed
-        mypy src/mcli/lib/logger/logger.py src/mcli/lib/custom_commands.py --ignore-missing-imports
+        python -m mypy src/mcli/lib/logger/logger.py src/mcli/lib/custom_commands.py --ignore-missing-imports
       continue-on-error: true  # Non-blocking until all function signatures are typed
 
   test-rust:
@@ -111,8 +111,13 @@ jobs:
     - name: Install system dependencies (Ubuntu)
       if: matrix.os == 'ubuntu-latest'
       run: |
-        sudo apt-get update
-        sudo apt-get install -y build-essential libpq-dev
+        # Self-hosted runners have no passwordless sudo and already ship build
+        # tooling; use non-interactive sudo and never fail the job on this step.
+        if sudo -n true 2>/dev/null; then
+          sudo -n apt-get update && sudo -n apt-get install -y build-essential libpq-dev
+        else
+          echo "::warning::Skipping apt-get (no passwordless sudo); assuming build-essential/libpq-dev present on self-hosted runner"
+        fi
 
     - name: Install system dependencies (macOS)
       if: matrix.os == 'macos-latest'

--- a/docs/releases/8.0.56.md
+++ b/docs/releases/8.0.56.md
@@ -1,0 +1,40 @@
+# Release Notes - Version 8.0.56
+
+**Release Date:** 2026-06-01
+
+## Overview
+
+Backlog closeout, batch 2 — acts on two triage decisions.
+
+## Changes
+
+- **#169 — CI rigor (make strict).** `pandas` and `pydot` (exercised by the ERD
+  / repo-graph tests) are now in the dev dependency group, and the
+  `test-python` job's `continue-on-error` mask is removed, so those tests gate
+  on real failures instead of silently passing. (The remaining
+  `continue-on-error` flags for flake8/mypy stay until #179 / #176 land — they
+  depend on large lint/type cleanups, not deps.)
+- **#178 — coverage on core command modules.** Added tests for `model_cmd`,
+  which previously had none. The tests double as a **regression guard for #165**
+  (the former `exec()` RCE): they assert that a malicious `model.json` is never
+  executed on import. (`sync`, `init`, and `setup` commands already have test
+  coverage.) #178 remains open as an ongoing coverage track.
+
+## Validation
+
+- New `tests/unit/test_model_cmd.py` (3 tests) green; RCE gadget in `model.json`
+  confirmed not executed.
+- pyproject validates; both dev groups carry pandas/pydot.
+
+## Upgrade Guide
+
+No breaking changes:
+
+```bash
+uv tool install mcli-framework --force
+```
+
+## Links
+
+- **PyPI**: https://pypi.org/project/mcli-framework/8.0.56/
+- **Full Changelog**: https://github.com/gwicho38/mcli/compare/v8.0.55...v8.0.56

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcli-framework"
-version = "8.0.55"
+version = "8.0.56"
 description = "Portable workflow framework - transform any script into a versioned, schedulable command. Store in ~/.mcli/workflows/, version with lockfile, run as daemon or cron job."
 readme = "README.md"
  requires-python = ">=3.10"
@@ -117,6 +117,10 @@ dev = [
   "bandit>=1.7.0",
   "safety>=3.0.0",
 
+  # Optional-feature deps exercised by the test suite (ERD/repo graphs) — kept
+  # in dev so CI can run those tests strictly instead of best-effort (#169).
+  "pandas>=2.0.0",
+  "pydot>=2.0.0",
   # Build tools
   "build>=1.2.2.post1",
   "maturin>=1.9.3",
@@ -298,6 +302,10 @@ dev = [
     # Security
     "bandit>=1.7.0",
     "safety>=3.0.0",
+    # Optional-feature deps exercised by the test suite (ERD/repo graphs) — kept
+    # in dev so CI can run those tests strictly instead of best-effort (#169).
+    "pandas>=2.0.0",
+    "pydot>=2.0.0",
     # Pre-commit / build / publish
     "pre-commit>=4.5.1",
     "build>=1.2.2.post1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ dev = [
   "pandas>=2.0.0",
   "pydot>=2.0.0",
   "openpyxl>=3.1.0",  # Excel engine for repo.py pd.ExcelWriter (#169)
+  "scikit-learn>=1.3.0",  # sklearn TF-IDF fallback for cached_vectorizer (pulls scipy) (#169)
   # Build tools
   "build>=1.2.2.post1",
   "maturin>=1.9.3",
@@ -308,6 +309,7 @@ dev = [
     "pandas>=2.0.0",
     "pydot>=2.0.0",
     "openpyxl>=3.1.0",  # Excel engine for repo.py pd.ExcelWriter (#169)
+    "scikit-learn>=1.3.0",  # sklearn TF-IDF fallback for cached_vectorizer (pulls scipy) (#169)
     # Pre-commit / build / publish
     "pre-commit>=4.5.1",
     "build>=1.2.2.post1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ dev = [
   # in dev so CI can run those tests strictly instead of best-effort (#169).
   "pandas>=2.0.0",
   "pydot>=2.0.0",
+  "openpyxl>=3.1.0",  # Excel engine for repo.py pd.ExcelWriter (#169)
   # Build tools
   "build>=1.2.2.post1",
   "maturin>=1.9.3",
@@ -306,6 +307,7 @@ dev = [
     # in dev so CI can run those tests strictly instead of best-effort (#169).
     "pandas>=2.0.0",
     "pydot>=2.0.0",
+    "openpyxl>=3.1.0",  # Excel engine for repo.py pd.ExcelWriter (#169)
     # Pre-commit / build / publish
     "pre-commit>=4.5.1",
     "build>=1.2.2.post1",

--- a/tests/unit/test_model_cmd.py
+++ b/tests/unit/test_model_cmd.py
@@ -1,0 +1,68 @@
+"""Tests for the model_cmd stub (#178 coverage) + #165 RCE regression guard.
+
+model_cmd was the module that previously `exec()`'d arbitrary code from a
+``model.json`` workflow file. It is now a safe stub: it must NEVER execute
+code found in model.json, regardless of whether such a file exists.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _reload_model_cmd():
+    """Re-import model_cmd so its module-level loading logic runs now."""
+    sys.modules.pop("mcli.app.model_cmd", None)
+    return importlib.import_module("mcli.app.model_cmd")
+
+
+def test_does_not_execute_code_from_model_json(tmp_path):
+    """A malicious model.json must NOT run on import (#165)."""
+    home = tmp_path
+    workflows = home / ".mcli" / "workflows"
+    workflows.mkdir(parents=True)
+    canary = tmp_path / "model_cmd_pwned_canary"
+    # A model.json whose "code" would create the canary if exec()'d.
+    (workflows / "model.json").write_text(
+        '{"name": "model", "code": "open(r\'%s\', \'w\').write(\'pwned\')"}' % canary
+    )
+
+    with patch.object(Path, "home", return_value=home):
+        mod = _reload_model_cmd()
+
+    # The gadget must not have executed.
+    assert not canary.exists(), "model.json code was executed — RCE regression!"
+    # The stub exposes the symbols but they are inert (None).
+    assert mod.model is None
+    assert mod.download is None
+
+
+def test_exposes_backwards_compat_symbols(tmp_path):
+    with patch.object(Path, "home", return_value=tmp_path):
+        mod = _reload_model_cmd()
+    for sym in [
+        "model",
+        "list",
+        "download",
+        "start",
+        "recommend",
+        "status",
+        "stop",
+        "pull",
+        "delete",
+    ]:
+        assert sym in mod.__all__
+        assert getattr(mod, sym) is None
+
+
+def test_no_model_json_is_safe(tmp_path):
+    """No model.json present → module still imports cleanly with inert symbols."""
+    with patch.object(Path, "home", return_value=tmp_path):
+        mod = _reload_model_cmd()
+    assert mod.model is None
+
+
+def teardown_module(_):
+    # Restore a clean import for any later test that imports model_cmd.
+    sys.modules.pop("mcli.app.model_cmd", None)


### PR DESCRIPTION
## Summary

Backlog closeout batch 2 — implements two triage decisions.

- **#169 (make CI strict):** add `pandas`/`pydot` (used by ERD/repo-graph tests) to the dev group and remove the `test-python` `continue-on-error` mask so those tests gate on real failures. flake8/mypy masks stay (depend on #179/#176).
- **#178 (core-command coverage):** add `tests/unit/test_model_cmd.py` — the previously-untested module that had the #165 `exec()` RCE. Tests double as a **#165 regression guard**: a malicious `model.json` must never execute on import. sync/init/setup already covered. #178 stays open as a coverage track.

## Validation
3 new tests green; RCE gadget confirmed not executed; pyproject valid. Version → 8.0.56.

Closes #169. Advances #178.

## Summary by Sourcery

Tighten Python CI by making optional-dependency tests gate on real failures and add regression-covering tests for the previously vulnerable model_cmd module, releasing these changes as version 8.0.56.

Build:
- Add pandas and pydot to the dev dependency group so ERD and repo-graph tests can run with required optional dependencies in CI.

CI:
- Remove the continue-on-error mask from the test-python job so test failures, including ERD/repo-graph coverage, now fail the pipeline.

Documentation:
- Add release notes for version 8.0.56 describing stricter CI behavior and new model_cmd regression tests.

Tests:
- Introduce unit tests for mcli.app.model_cmd that verify it exposes inert compatibility symbols and does not execute code from model.json on import.

Chores:
- Bump project version from 8.0.55 to 8.0.56.