### PR TITLE
fix(ci): preflight runs ci.yml primary instead of hollow-passing dispatch-only repos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcli-framework"
-version = "8.0.56"
+version = "8.0.57"
 description = "Portable workflow framework - transform any script into a versioned, schedulable command. Store in ~/.mcli/workflows/, version with lockfile, run as daemon or cron job."
 readme = "README.md"
  requires-python = ">=3.10"

--- a/src/mcli/workflow/ci/act_runner.py
+++ b/src/mcli/workflow/ci/act_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import platform
 import shutil
 import subprocess
 import sys
@@ -26,6 +27,14 @@ _NO_STAGES_MARKERS = ("could not find any stages to run",)
 # Backoff (seconds) between docker rate-limit retries; the last value repeats.
 _RETRY_BACKOFF = (15, 45)
 _MAX_RETRIES = 2
+
+# Canonical CI entrypoint created by `mcli ci migrate`: ci.yml's `primary` job
+# runs on `workflow_dispatch` and calls the reusable `_ci-jobs.yml` with the
+# `runner_labels` input. The reusable workflow CANNOT run standalone (its
+# `runs-on: ${{ fromJSON(inputs.runner_labels) }}` has no value), so preflight
+# must drive it through this caller.
+_DISPATCH_WORKFLOW = Path(".github/workflows/ci.yml")
+_DISPATCH_JOB = "primary"
 
 
 class PreflightResult(Enum):
@@ -67,48 +76,63 @@ def probe() -> bool:
     return proc.returncode == 0
 
 
-def build_act_command(event: str) -> list[str]:
+def default_container_arch() -> str | None:
+    """`--container-architecture` value for the host, or None to let act decide.
+
+    act's runner images are amd64. On Apple-silicon (darwin/arm64) act warns and
+    misbehaves unless told to emulate amd64, so force it; native amd64 Linux
+    needs nothing.
+    """
+    if sys.platform == "darwin" and platform.machine() in ("arm64", "aarch64"):
+        return "linux/amd64"
+    return None
+
+
+def dispatch_entrypoint() -> tuple[str, str] | None:
+    """The canonical (workflow, job) to drive via `workflow_dispatch`, or None."""
+    if _DISPATCH_WORKFLOW.exists():
+        return (str(_DISPATCH_WORKFLOW), _DISPATCH_JOB)
+    return None
+
+
+def build_act_command(
+    event: str,
+    workflow: str | None = None,
+    job: str | None = None,
+    arch: str | None = None,
+) -> list[str]:
     cmd = ["act", event]
+    if workflow is not None:
+        cmd += ["-W", workflow]
+    if job is not None:
+        cmd += ["-j", job]
+    if arch is not None:
+        cmd += ["--container-architecture", arch]
     if Path(".secrets").exists():
         cmd += ["--secret-file", ".secrets"]
     return cmd
 
 
-def run_act(
-    event: str = "pull_request",
-    retries: int = _MAX_RETRIES,
-    backoff: tuple[int, ...] = _RETRY_BACKOFF,
-) -> PreflightResult:
-    """Run act for `event` and classify the outcome.
-
-    - exit 0 -> PASS.
-    - non-zero whose output shows a Docker Hub pull rate limit
-      (``toomanyrequests``) -> retry up to ``retries`` times with backoff;
-      if still rate-limited, return UNREACHABLE (cannot validate — an
-      environment problem, not a test failure, so the gate must not block).
-    - any other non-zero exit -> FAIL.
-
-    Output is captured (to detect the rate limit) and echoed so the user still
-    sees act's progress.
-    """
+def _run_with_retries(
+    cmd: list[str], retries: int, backoff: tuple[int, ...]
+) -> tuple[PreflightResult, str]:
+    """Run one act command, retrying on Docker Hub rate limits. Returns the
+    classified result plus the combined output (so the caller can detect the
+    'no stages' no-op and decide whether to fall back)."""
     attempt = 0
     while True:
-        proc = subprocess.run(build_act_command(event), capture_output=True, text=True)
+        proc = subprocess.run(cmd, capture_output=True, text=True)
         output = (proc.stdout or "") + (proc.stderr or "")
         if output:
             sys.stdout.write(output if output.endswith("\n") else output + "\n")
 
         if proc.returncode == 0:
-            return PreflightResult.PASS
+            return PreflightResult.PASS, output
 
-        # No job matches this event (e.g. workflow_dispatch-only) — nothing to
-        # validate, so this is a pass, not a gate failure.
+        # No job matches this event (e.g. workflow_dispatch-only). PASS here is
+        # provisional — run_act decides whether a dispatch fallback exists.
         if _has_no_stages(output):
-            sys.stdout.write(
-                "ℹ️  No act stages for this event (workflow_dispatch-only?); "
-                "nothing to validate — treating as pass.\n"
-            )
-            return PreflightResult.PASS
+            return PreflightResult.PASS, output
 
         if _is_docker_rate_limited(output):
             if attempt < retries:
@@ -124,9 +148,54 @@ def run_act(
                 "⚠️  Docker Hub still rate-limited after retries — cannot validate "
                 "locally; allowing push (run `mcli ci preflight` again later).\n"
             )
-            return PreflightResult.UNREACHABLE
+            return PreflightResult.UNREACHABLE, output
 
-        return PreflightResult.FAIL
+        return PreflightResult.FAIL, output
+
+
+def run_act(
+    event: str = "pull_request",
+    retries: int = _MAX_RETRIES,
+    backoff: tuple[int, ...] = _RETRY_BACKOFF,
+) -> PreflightResult:
+    """Run act for `event` and classify the outcome.
+
+    - exit 0 -> PASS.
+    - non-zero whose output shows a Docker Hub pull rate limit
+      (``toomanyrequests``) -> retried; if still limited, UNREACHABLE.
+    - any other non-zero exit -> FAIL.
+
+    Migrated repos are ``workflow_dispatch``-only, so the default
+    ``pull_request`` event matches no jobs. Rather than hollow-pass, fall back
+    to the canonical ``ci.yml`` ``primary`` job on ``workflow_dispatch`` (which
+    drives the reusable ``_ci-jobs.yml``) and validate for real.
+    """
+    arch = default_container_arch()
+    result, output = _run_with_retries(build_act_command(event, arch=arch), retries, backoff)
+
+    if result == PreflightResult.PASS and _has_no_stages(output):
+        entry = dispatch_entrypoint()
+        if entry is None:
+            sys.stdout.write(
+                "ℹ️  No act stages for this event and no ci.yml dispatch "
+                "entrypoint — nothing to validate; treating as pass.\n"
+            )
+            return PreflightResult.PASS
+        workflow, job = entry
+        sys.stdout.write(
+            f"ℹ️  No '{event}' stages (workflow_dispatch-only); running "
+            f"{workflow} -j {job} via workflow_dispatch…\n"
+        )
+        result, output = _run_with_retries(
+            build_act_command("workflow_dispatch", workflow=workflow, job=job, arch=arch),
+            retries,
+            backoff,
+        )
+        # If even the dispatch entrypoint has no stages, it's a genuine no-op.
+        if result == PreflightResult.PASS and _has_no_stages(output):
+            return PreflightResult.PASS
+
+    return result
 
 
 def preflight(repo_slug: str, event: str = "pull_request") -> PreflightResult:

--- a/tests/unit/workflow/test_ci_act_runner.py
+++ b/tests/unit/workflow/test_ci_act_runner.py
@@ -3,7 +3,14 @@
 import subprocess
 from unittest.mock import patch
 
-from mcli.workflow.ci.act_runner import PreflightResult, build_act_command, probe, run_act
+from mcli.workflow.ci.act_runner import (
+    PreflightResult,
+    build_act_command,
+    default_container_arch,
+    preflight,
+    probe,
+    run_act,
+)
 
 
 def _cp(returncode=0, stdout=""):
@@ -46,6 +53,35 @@ class TestBuildCommand:
         cmd = build_act_command("push")
         assert "--secret-file" not in cmd
 
+    def test_workflow_job_arch_flags(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cmd = build_act_command(
+            "workflow_dispatch",
+            workflow=".github/workflows/ci.yml",
+            job="primary",
+            arch="linux/amd64",
+        )
+        assert cmd[:2] == ["act", "workflow_dispatch"]
+        assert cmd[cmd.index("-W") + 1] == ".github/workflows/ci.yml"
+        assert cmd[cmd.index("-j") + 1] == "primary"
+        assert cmd[cmd.index("--container-architecture") + 1] == "linux/amd64"
+
+
+class TestDefaultArch:
+    def test_amd64_on_macos_arm(self):
+        with (
+            patch("mcli.workflow.ci.act_runner.sys.platform", "darwin"),
+            patch("platform.machine", return_value="arm64"),
+        ):
+            assert default_container_arch() == "linux/amd64"
+
+    def test_none_on_linux(self):
+        with (
+            patch("mcli.workflow.ci.act_runner.sys.platform", "linux"),
+            patch("platform.machine", return_value="x86_64"),
+        ):
+            assert default_container_arch() is None
+
 
 class TestRunAct:
     def test_pass(self):
@@ -56,12 +92,51 @@ class TestRunAct:
         with patch("subprocess.run", return_value=_cp(1)):
             assert run_act("pull_request") == PreflightResult.FAIL
 
-    def test_no_stages_is_pass_not_fail(self):
-        """workflow_dispatch-only workflows have no pull_request stages; act
-        exits non-zero with 'Could not find any stages to run' — a no-op, not
-        a failure, so the gate must not block (#205)."""
+    def test_no_stages_without_entrypoint_is_pass(self, tmp_path, monkeypatch):
+        """No pull_request stages AND no ci.yml dispatch entrypoint -> genuine
+        no-op, so the gate must not block (#205)."""
+        monkeypatch.chdir(tmp_path)  # no .github/workflows/ci.yml here
         out = "Error: Could not find any stages to run. View the valid jobs with `act --list`."
         with patch("subprocess.run", return_value=_cp(1, stdout=out)):
+            assert run_act("pull_request") == PreflightResult.PASS
+
+
+class TestDispatchFallback:
+    """workflow_dispatch-only repos (migrated by `mcli ci migrate`) have no
+    pull_request stages. Rather than hollow-pass, preflight must run the
+    canonical ci.yml `primary` job via workflow_dispatch so it actually
+    validates the gates."""
+
+    _NO_STAGES = "Error: Could not find any stages to run."
+
+    def _with_ci_yml(self, tmp_path, monkeypatch):
+        wf = tmp_path / ".github" / "workflows"
+        wf.mkdir(parents=True)
+        (wf / "ci.yml").write_text("name: ci\non:\n  workflow_dispatch:\n")
+        monkeypatch.chdir(tmp_path)
+
+    def test_no_stages_then_dispatch_passes(self, tmp_path, monkeypatch):
+        self._with_ci_yml(tmp_path, monkeypatch)
+        # 1st call (pull_request) -> no stages; 2nd call (dispatch) -> exit 0.
+        seq = [_cp(1, stdout=self._NO_STAGES), _cp(0)]
+        with patch("subprocess.run", side_effect=seq) as m:
+            assert run_act("pull_request") == PreflightResult.PASS
+        assert m.call_count == 2
+        # 2nd invocation targets ci.yml primary on workflow_dispatch.
+        second = m.call_args_list[1].args[0]
+        assert "workflow_dispatch" in second
+        assert "-j" in second and "primary" in second
+
+    def test_no_stages_then_dispatch_fails(self, tmp_path, monkeypatch):
+        self._with_ci_yml(tmp_path, monkeypatch)
+        seq = [_cp(1, stdout=self._NO_STAGES), _cp(1, stdout="3 tests failed")]
+        with patch("subprocess.run", side_effect=seq):
+            assert run_act("pull_request") == PreflightResult.FAIL
+
+    def test_dispatch_also_no_stages_is_pass(self, tmp_path, monkeypatch):
+        self._with_ci_yml(tmp_path, monkeypatch)
+        seq = [_cp(1, stdout=self._NO_STAGES), _cp(1, stdout=self._NO_STAGES)]
+        with patch("subprocess.run", side_effect=seq):
             assert run_act("pull_request") == PreflightResult.PASS
 
 
@@ -95,9 +170,6 @@ class TestRunActDockerRateLimit:
         ):
             assert run_act("pull_request") == PreflightResult.FAIL
         assert m.call_count == 1
-
-
-from mcli.workflow.ci.act_runner import preflight
 
 
 class TestPreflight:


### PR DESCRIPTION
## Problem

Repos migrated by `mcli ci migrate` are `workflow_dispatch`-only (hosted `push`/`pull_request` triggers stripped). `mcli ci preflight` runs `act pull_request`, which matches **no jobs**, and the runner treated `Could not find any stages to run` as **PASS**.

Result: `mcli ci preflight`, `mcli ci pr`, and the pre-push hook were **green without running any gates** — a silent hollow-pass. (Hit in praxis: every local validation "passed" while validating nothing.)

## Fix

When the requested event yields no stages, fall back to the canonical entrypoint the migration creates — `ci.yml`'s `primary` job — via `workflow_dispatch`:

```
act workflow_dispatch -W .github/workflows/ci.yml -j primary [--container-architecture linux/amd64]
```

`primary` drives the reusable `_ci-jobs.yml` with `runner_labels` (the reusable workflow can't run standalone — its `runs-on: ${{ fromJSON(inputs.runner_labels) }}` has no value otherwise). Only a genuinely missing `ci.yml` still no-op-passes.

Also force `--container-architecture linux/amd64` on Apple-silicon so act's amd64 runner images run instead of warning/misbehaving.

## Tests

- `TestDispatchFallback`: no-stages → runs ci.yml primary; classifies dispatch PASS / FAIL; dispatch-also-no-stages → pass.
- `TestDefaultArch`: amd64 on darwin/arm64, None on linux.
- `build_act_command` workflow/job/arch flags; no-stages-without-entrypoint still passes.
- Full ci suite: 38 passed. Validated live on praxis: the dispatch invocation runs all 4 gate jobs on podman/arm64.

bump 8.0.56 → 8.0.57

## Summary by Sourcery

Ensure local CI preflight runs the primary workflow job instead of silently passing when no act stages match the requested event.

Bug Fixes:
- Prevent preflight and PR CI commands from hollow-passing when repos are workflow_dispatch-only by falling back to running the canonical ci.yml primary job.
- Avoid act misbehavior on Apple silicon hosts by forcing the container architecture to linux/amd64 when needed.

Tests:
- Add unit coverage for dispatch fallback behavior when no stages are found, including both pass and fail outcomes and true no-op cases without a dispatch entrypoint.
- Add tests for the default container architecture selection on different host platforms and for extended act command construction with workflow, job, and architecture flags.

Chores:
- Bump framework version from 8.0.56 to 8.0.57.