### PR TITLE
feat(ci): preflight prefers native `make ci-native` gate over act

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcli-framework"
-version = "8.0.57"
+version = "8.0.58"
 description = "Portable workflow framework - transform any script into a versioned, schedulable command. Store in ~/.mcli/workflows/, version with lockfile, run as daemon or cron job."
 readme = "README.md"
  requires-python = ">=3.10"

--- a/src/mcli/workflow/ci/act_runner.py
+++ b/src/mcli/workflow/ci/act_runner.py
@@ -57,6 +57,33 @@ def act_available() -> bool:
     return shutil.which("act") is not None
 
 
+# Preferred over act when present: a repo-defined `make ci-native` target runs
+# the same gates directly on the host toolchain. On Apple-silicon (and any host
+# without nested-virt) act's amd64 emulation under podman is flaky for heavy
+# jobs (container-vanish races, action-clone failures), so a native run is both
+# faster and more reliable. Repos opt in simply by defining the target.
+_NATIVE_GATE = "ci-native"
+
+
+def native_gate_available() -> bool:
+    """True if the repo defines a `make ci-native` target (preferred over act)."""
+    try:
+        proc = subprocess.run(
+            ["make", "-n", _NATIVE_GATE], capture_output=True, text=True, timeout=30
+        )
+        return proc.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def run_native() -> PreflightResult:
+    """Run the repo's native gate (`make ci-native`) on the host. PASS on exit 0,
+    FAIL otherwise. Output streams straight to the terminal (these runs are long;
+    no need to buffer)."""
+    proc = subprocess.run(["make", _NATIVE_GATE])
+    return PreflightResult.PASS if proc.returncode == 0 else PreflightResult.FAIL
+
+
 def docker_running() -> bool:
     try:
         proc = subprocess.run(["docker", "info"], capture_output=True, timeout=30)
@@ -203,7 +230,13 @@ def preflight(repo_slug: str, event: str = "pull_request") -> PreflightResult:
 
     `repo_slug` is accepted for symmetry and future use; the runner fallback is
     orchestrated by the CLI layer based on runner_status.has_online_runner.
+
+    Prefers a repo-defined native gate (`make ci-native`) over act: it runs the
+    same checks on the host toolchain, avoiding act's flaky container emulation.
     """
+    if native_gate_available():
+        sys.stdout.write("▶ Native CI gate found — running `make ci-native` (no act)…\n")
+        return run_native()
     if not probe():
         return PreflightResult.UNREACHABLE
     return run_act(event)

--- a/tests/unit/workflow/test_ci_act_runner.py
+++ b/tests/unit/workflow/test_ci_act_runner.py
@@ -7,9 +7,11 @@ from mcli.workflow.ci.act_runner import (
     PreflightResult,
     build_act_command,
     default_container_arch,
+    native_gate_available,
     preflight,
     probe,
     run_act,
+    run_native,
 )
 
 
@@ -172,9 +174,60 @@ class TestRunActDockerRateLimit:
         assert m.call_count == 1
 
 
+class TestNativeGate:
+    def test_available_true_on_exit0(self):
+        with patch("subprocess.run", return_value=_cp(0)):
+            assert native_gate_available() is True
+
+    def test_available_false_when_target_missing(self):
+        # `make -n ci-native` exits 2 when the target doesn't exist.
+        with patch("subprocess.run", return_value=_cp(2)):
+            assert native_gate_available() is False
+
+    def test_available_false_when_make_missing(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError()):
+            assert native_gate_available() is False
+
+    def test_run_native_pass(self):
+        with patch("subprocess.run", return_value=_cp(0)):
+            assert run_native() == PreflightResult.PASS
+
+    def test_run_native_fail(self):
+        with patch("subprocess.run", return_value=_cp(1)):
+            assert run_native() == PreflightResult.FAIL
+
+
 class TestPreflight:
+    def test_prefers_native_gate_over_act(self):
+        # When a native `make ci-native` exists, run it and SKIP act entirely.
+        with (
+            patch("mcli.workflow.ci.act_runner.native_gate_available", return_value=True),
+            patch("mcli.workflow.ci.act_runner.run_native", return_value=PreflightResult.PASS),
+            patch("mcli.workflow.ci.act_runner.probe") as probe_m,
+            patch("mcli.workflow.ci.act_runner.run_act") as act_m,
+        ):
+            assert preflight("o/r") == PreflightResult.PASS
+            probe_m.assert_not_called()
+            act_m.assert_not_called()
+
+    def test_native_fail_blocks(self):
+        with (
+            patch("mcli.workflow.ci.act_runner.native_gate_available", return_value=True),
+            patch("mcli.workflow.ci.act_runner.run_native", return_value=PreflightResult.FAIL),
+        ):
+            assert preflight("o/r") == PreflightResult.FAIL
+
+    def test_falls_back_to_act_without_native_gate(self):
+        with (
+            patch("mcli.workflow.ci.act_runner.native_gate_available", return_value=False),
+            patch("mcli.workflow.ci.act_runner.probe", return_value=True),
+            patch("mcli.workflow.ci.act_runner.run_act", return_value=PreflightResult.PASS),
+        ):
+            assert preflight("o/r") == PreflightResult.PASS
+
     def test_act_passes(self):
         with (
+            patch("mcli.workflow.ci.act_runner.native_gate_available", return_value=False),
             patch("mcli.workflow.ci.act_runner.probe", return_value=True),
             patch("mcli.workflow.ci.act_runner.run_act", return_value=PreflightResult.PASS),
         ):
@@ -182,6 +235,7 @@ class TestPreflight:
 
     def test_act_fails_blocks(self):
         with (
+            patch("mcli.workflow.ci.act_runner.native_gate_available", return_value=False),
             patch("mcli.workflow.ci.act_runner.probe", return_value=True),
             patch("mcli.workflow.ci.act_runner.run_act", return_value=PreflightResult.FAIL),
         ):
@@ -189,5 +243,8 @@ class TestPreflight:
 
     def test_unreachable_with_runner_is_unreachable(self):
         # Fallback to runner is handled by the CLI layer; preflight reports UNREACHABLE.
-        with patch("mcli.workflow.ci.act_runner.probe", return_value=False):
+        with (
+            patch("mcli.workflow.ci.act_runner.native_gate_available", return_value=False),
+            patch("mcli.workflow.ci.act_runner.probe", return_value=False),
+        ):
             assert preflight("o/r") == PreflightResult.UNREACHABLE


### PR DESCRIPTION
## Why

Follow-up to #211. Even with the dispatch fallback, act on Apple-silicon runs amd64 runner images under podman emulation, which is **flaky for heavy jobs** — container-vanish races (`no such container … found in database`), action-clone failures (`git clone … some refs were not updated`). A correct invocation still can't reliably gate.

## What

`preflight` now prefers a repo-defined **`make ci-native`** target — the same checks run directly on the host toolchain (no containers, no emulation) — and skips act entirely when it's present. Repos without the target keep the act path (with the 8.0.57 dispatch fallback).

```
preflight()
  ├─ make -n ci-native exits 0 ?  → run `make ci-native` (host) → PASS/FAIL   [NEW]
  └─ else                         → probe() → run_act() (dispatch fallback)
```

Opt-in is just defining the target; nothing changes for repos that don't.

## Tests
- `TestNativeGate`: available true/false (exit 0 / 2 / make-missing); run_native PASS/FAIL.
- `TestPreflight`: prefers native + skips probe/act; native FAIL blocks; falls back to act without a native gate.
- Full ci suite: 28 passed, lint clean.

bump 8.0.57 → 8.0.58

## Summary by Sourcery

Prefer a repo-defined native CI gate over act-based workflows in preflight checks and bump the framework version.

New Features:
- Add support for a native CI gate via a `make ci-native` target that runs checks directly on the host and is preferred over act when available.

Enhancements:
- Update preflight logic to short-circuit to the native CI gate when present and only use act as a fallback.
- Improve CI preflight messaging to indicate when the native gate is being used.

Build:
- Bump project version from 8.0.57 to 8.0.58.

Tests:
- Extend unit tests to cover native gate availability and execution, and to verify preflight’s preference and fallback behavior.