### PR TITLE
fix: recreate stale global venv with uv --clear

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,11 +71,32 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: false
 
+  # Job 1b: Version guard — fail if pyproject version already exists on PyPI.
+  # Without this, publish uses skip-existing:true and silently no-ops when the
+  # version wasn't bumped, so downstream PyPI consumers never receive the change.
+  version-guard:
+    name: Version Guard
+    runs-on: [self-hosted, linux, x64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Ensure version is bumped (not already on PyPI)
+        run: |
+          VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "//;s/"//')
+          echo "pyproject version: $VERSION"
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' "https://pypi.org/pypi/mcli-framework/$VERSION/json")
+          if [ "$STATUS" = "200" ]; then
+            echo "::error::Version $VERSION is already published on PyPI. Bump 'version' in pyproject.toml before merging — publish uses skip-existing and would silently no-op."
+            exit 1
+          fi
+          echo "Version $VERSION is free on PyPI — OK to publish."
+
   # Job 2: Build package
   build:
     name: Build Distribution
     runs-on: [self-hosted, linux, x64]
-    needs: test
+    needs: [test, version-guard]
 
     steps:
       - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcli-framework"
-version = "8.0.58"
+version = "8.0.59"
 description = "Portable workflow framework - transform any script into a versioned, schedulable command. Store in ~/.mcli/workflows/, version with lockfile, run as daemon or cron job."
 readme = "README.md"
  requires-python = ">=3.10"

--- a/src/mcli/lib/constants/messages.py
+++ b/src/mcli/lib/constants/messages.py
@@ -1124,6 +1124,7 @@ class VenvMessages:
     USING_SYSTEM_PYTHON_ENV_SET = "Using system Python (MCLI_USE_SYSTEM_PYTHON set)"
     CREATING_GLOBAL_VENV = "Creating global MCLI venv at {path}..."
     GLOBAL_VENV_CREATED = "Created global MCLI venv at {path}"
+    GLOBAL_VENV_ALREADY_EXISTS = "Global venv already exists at {path}"
 
     # Dependency messages
     NO_DEPS_SPECIFIED = "No dependencies specified"

--- a/src/mcli/lib/pyenv/venv.py
+++ b/src/mcli/lib/pyenv/venv.py
@@ -67,7 +67,7 @@ class VenvManager:
         venv_path = self.get_global_venv_path()
 
         if venv_path.is_dir() and self._is_valid_venv(venv_path):
-            logger.debug(f"Global venv already exists at {venv_path}")
+            logger.debug(VenvMessages.GLOBAL_VENV_ALREADY_EXISTS.format(path=venv_path))
             return venv_path
 
         logger.info(VenvMessages.CREATING_GLOBAL_VENV.format(path=venv_path))
@@ -95,8 +95,12 @@ class VenvManager:
         venv_path.parent.mkdir(parents=True, exist_ok=True)
 
         try:
+            # --clear recreates over an existing directory. ensure_global_venv()
+            # only calls this when no *valid* venv exists, so a directory present
+            # here is stale/partial (e.g. pyvenv.cfg but no bin/python). Without
+            # --clear, uv aborts with "A virtual environment already exists".
             result = subprocess.run(
-                ["uv", "venv", str(venv_path)],
+                ["uv", "venv", "--clear", str(venv_path)],
                 capture_output=True,
                 text=True,
                 timeout=60,

--- a/tests/unit/test_pyenv.py
+++ b/tests/unit/test_pyenv.py
@@ -157,6 +157,33 @@ class TestVenvManager:
             assert str(venv_path / "bin") in result["PATH"]
             assert "PYTHONHOME" not in result
 
+    def test_create_venv_clears_existing_dir(self):
+        """create_venv must pass --clear so a partial/corrupt venv is recreated.
+
+        Regression: when ~/.mcli/venv exists with pyvenv.cfg but no bin/python,
+        `uv venv <path>` aborts with "A virtual environment already exists".
+        Passing --clear lets uv recreate over the existing directory.
+        """
+        from unittest.mock import MagicMock
+
+        from mcli.lib.pyenv import VenvManager
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            venv_path = Path(tmpdir) / "venv"
+
+            manager = VenvManager()
+
+            completed = MagicMock(returncode=0, stdout="", stderr="")
+            with patch.object(VenvManager, "is_uv_available", return_value=True):
+                with patch(
+                    "mcli.lib.pyenv.venv.subprocess.run", return_value=completed
+                ) as mock_run:
+                    assert manager.create_venv(venv_path) is True
+
+            cmd = mock_run.call_args[0][0]
+            assert cmd[:3] == ["uv", "venv", "--clear"], cmd
+            assert str(venv_path) in cmd
+
 
 class TestDependencyChecker:
     """Test suite for DependencyChecker class."""


### PR DESCRIPTION
## Problem

\`mcli run -g <cmd>\` aborts when \`~/.mcli/venv\` is a **partial/corrupt** venv (has \`pyvenv.cfg\` but no \`bin/python\`):

\`\`\`
Error executing Python command: Failed to create virtual environment
error: Failed to create virtual environment
  Caused by: A virtual environment already exists at: /Users/home/.mcli/venv
hint: Use the \`--clear\` flag or set \`UV_VENV_CLEAR=1\` to replace the existing virtual environment
\`\`\`

## Root cause

\`VenvManager.ensure_global_venv()\` decides "valid" via \`_is_valid_venv()\` (checks \`bin/python\`); uv decides "is a venv" via \`pyvenv.cfg\`. When the two disagree, mcli calls \`create_venv()\` → \`uv venv <path>\` → uv refuses the existing dir → permanent deadlock mcli can never self-heal from.

## Before / After

**Before**
\`\`\`mermaid
flowchart TD
  A[ensure_global_venv] --> B{bin/python exists?}
  B -- no --> C["uv venv PATH"]
  C --> D{dir already exists?}
  D -- yes --> E[ABORT: already exists]
\`\`\`

**After**
\`\`\`mermaid
flowchart TD
  A[ensure_global_venv] --> B{bin/python exists?}
  B -- no --> C["uv venv --clear PATH"]
  C --> F[recreate over stale dir]
  F --> G[venv ready]
\`\`\`

## Change

- \`src/mcli/lib/pyenv/venv.py\`: add \`--clear\` to the \`uv venv\` invocation. Only reached when no *valid* venv exists, so clearing is always correct and self-heals corrupt venvs.
- Moves a pre-existing hardcoded debug string into \`VenvMessages.GLOBAL_VENV_ALREADY_EXISTS\` (linter).
- Adds regression test \`test_create_venv_clears_existing_dir\`.

## Test

\`uv run pytest tests/unit/test_pyenv.py tests/unit/test_uv_compat.py -q\` → all pass (28). Regression test red before fix, green after.

## Summary by Sourcery

Ensure global virtual environments are recreated when stale and improve messaging around existing venvs.

Bug Fixes:
- Force uv to recreate an existing but invalid global venv directory by invoking `uv venv` with the `--clear` flag.

Enhancements:
- Use a dedicated VenvMessages constant for the 'global venv already exists' debug log message.

Build:
- Bump project version from 8.0.58 to 8.0.59.

Tests:
- Add a regression test verifying that create_venv calls `uv venv --clear` and targets the expected directory.