### PR TITLE
fix: seed base runtime (click) into isolated venv for workflow scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcli-framework"
-version = "8.0.59"
+version = "8.0.60"
 description = "Portable workflow framework - transform any script into a versioned, schedulable command. Store in ~/.mcli/workflows/, version with lockfile, run as daemon or cron job."
 readme = "README.md"
  requires-python = ">=3.10"

--- a/src/mcli/lib/constants/paths.py
+++ b/src/mcli/lib/constants/paths.py
@@ -101,5 +101,11 @@ class VenvPaths:
     PYTHON_UNIX = "python"
     PYTHON_WINDOWS = "python.exe"
 
+    # Framework runtime primitives that mcli python workflows assume are
+    # importable. The generated script templates `import click` unconditionally,
+    # so an isolated (bare) global venv must be seeded with these even when a
+    # script omits them from its @requires metadata.
+    BASE_RUNTIME_PACKAGES = ["click"]
+
 
 __all__ = ["DirNames", "FileNames", "PathPatterns", "GitIgnorePatterns", "VenvPaths"]

--- a/src/mcli/lib/pyenv/deps.py
+++ b/src/mcli/lib/pyenv/deps.py
@@ -75,6 +75,26 @@ class DependencyChecker:
 
         return installed, missing
 
+    def merge_base_runtime(self, packages: List[str], base: List[str]) -> List[str]:
+        """Append base runtime packages that are not already declared.
+
+        Comparison is by normalized package name, so a declared spec like
+        ``click>=8.0`` or ``Click`` suppresses adding the bare ``click`` base.
+
+        Args:
+            packages: Packages already requested (from @requires).
+            base: Base runtime packages to ensure are present.
+
+        Returns:
+            ``packages`` plus any base package whose normalized name is absent.
+        """
+        have = {self._normalize_package_name(self._extract_package_name(p)) for p in packages}
+        merged = list(packages)
+        for pkg in base:
+            if self._normalize_package_name(self._extract_package_name(pkg)) not in have:
+                merged.append(pkg)
+        return merged
+
     def install_packages(self, packages: List[str], venv_path: Path) -> bool:
         """Install packages using uv pip install.
 

--- a/src/mcli/lib/pyenv/manager.py
+++ b/src/mcli/lib/pyenv/manager.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Optional, Tuple
 
 import click
 
-from mcli.lib.constants import EnvVars, VenvMessages
+from mcli.lib.constants import EnvVars, VenvMessages, VenvPaths
 from mcli.lib.logger import get_logger
 
 from .deps import DependencyChecker
@@ -119,10 +119,6 @@ class PyEnvManager:
         Returns:
             True if all dependencies are satisfied or installed.
         """
-        if not requires:
-            logger.debug(VenvMessages.NO_DEPS_SPECIFIED)
-            return True
-
         venv_path, source = self.resolve_environment()
 
         # Ensure the venv exists (create global venv if needed)
@@ -132,8 +128,16 @@ class PyEnvManager:
         python_exe = self.get_python_executable()
         checker = DependencyChecker(python_exe)
 
-        # Parse and check dependencies
-        packages = checker.parse_requires(requires)
+        # Parse declared dependencies, then ensure framework runtime primitives
+        # (e.g. click) are present even when @requires is empty — an isolated
+        # global venv is created bare and mcli workflow scripts import click.
+        packages = checker.parse_requires(requires) if requires else []
+        packages = checker.merge_base_runtime(packages, VenvPaths.BASE_RUNTIME_PACKAGES)
+
+        if not packages:
+            logger.debug(VenvMessages.NO_DEPS_SPECIFIED)
+            return True
+
         logger.debug(VenvMessages.CHECKING_DEPS.format(script=script_name))
 
         installed, missing = checker.check_installed(packages)

--- a/tests/unit/test_pyenv.py
+++ b/tests/unit/test_pyenv.py
@@ -256,6 +256,26 @@ class TestDependencyChecker:
         assert checker._check_version_constraint("pandas>=1.0.0", "1.5.0") is True
         assert checker._check_version_constraint("pandas", "1.0.0") is True
 
+    def test_merge_base_runtime_adds_missing(self):
+        """merge_base_runtime appends base packages not already present."""
+        from mcli.lib.pyenv import DependencyChecker
+
+        checker = DependencyChecker(Path(sys.executable))
+
+        assert checker.merge_base_runtime([], ["click"]) == ["click"]
+        assert checker.merge_base_runtime(["rich"], ["click"]) == ["rich", "click"]
+
+    def test_merge_base_runtime_no_duplicate(self):
+        """Base packages already declared (any form) are not duplicated."""
+        from mcli.lib.pyenv import DependencyChecker
+
+        checker = DependencyChecker(Path(sys.executable))
+
+        # bare, version-pinned, and normalized-name variants all suppress the add
+        assert checker.merge_base_runtime(["click"], ["click"]) == ["click"]
+        assert checker.merge_base_runtime(["click>=8.0.0"], ["click"]) == ["click>=8.0.0"]
+        assert checker.merge_base_runtime(["Click"], ["click"]) == ["Click"]
+
 
 class TestPyEnvManager:
     """Test suite for PyEnvManager class."""
@@ -426,6 +446,43 @@ class TestCheckAndInstallDeps:
 
                     assert result is False
                     mock_confirm.assert_called_once()
+
+    def test_base_runtime_installed_when_no_requires(self):
+        """Even with no @requires, base runtime (click) must be ensured.
+
+        Regression: generated python workflow templates import click but do not
+        declare it; a bare global venv has no click, so `mcli run -g <cmd>`
+        crashed with ModuleNotFoundError: No module named 'click'. The empty
+        @requires must NOT short-circuit before base deps are installed.
+        """
+        from mcli.lib.pyenv import PyEnvManager
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+
+            with patch.dict(os.environ, {"MCLI_USE_SYSTEM_PYTHON": "true"}):
+                manager = PyEnvManager(workspace_dir=workspace)
+
+                with (
+                    patch.object(manager, "resolve_environment", return_value=(None, "system")),
+                    patch.object(
+                        manager, "get_python_executable", return_value=Path(sys.executable)
+                    ),
+                    patch("mcli.lib.pyenv.manager.DependencyChecker") as mock_checker_cls,
+                    patch("sys.stdin") as mock_stdin,
+                ):
+                    mock_stdin.isatty.return_value = False
+                    mock_checker = mock_checker_cls.return_value
+                    mock_checker.merge_base_runtime.return_value = ["click"]
+                    mock_checker.check_installed.return_value = ([], ["click"])
+                    mock_checker.install_packages.return_value = None
+
+                    result = manager.check_and_install_deps([], "test_script")
+
+                    assert result is True
+                    mock_checker.install_packages.assert_called_once()
+                    installed_arg = mock_checker.install_packages.call_args[0][0]
+                    assert "click" in installed_arg
 
 
 class TestPyEnvIntegration:


### PR DESCRIPTION
## Problem

Follow-up to #213. After the venv-creation deadlock fix, `mcli run -g <cmd>` creates the global venv but it is **bare**, so workflow scripts crash:

```
ModuleNotFoundError: No module named 'click'
```

## Root cause

- The generated python workflow template (`new_cmd.py`) **imports `click` unconditionally** but never adds `@requires: click`.
- `check_and_install_deps()` **early-returned** when `@requires` was empty, so nothing was installed into the isolated venv.
- The dev `.venv` masked this — it already has `click`/`mcli` installed; only the bare global venv exposed it.

## Before / After

**Before**
```mermaid
flowchart TD
  A[run -g script] --> B[ensure global venv: bare]
  B --> C{"@requires empty?"}
  C -- yes --> D[return early, install nothing]
  D --> E[exec script]
  E --> F["import click -> ModuleNotFoundError"]
```

**After**
```mermaid
flowchart TD
  A[run -g script] --> B[ensure global venv]
  B --> G["merge_base_runtime: @requires + click"]
  G --> H[install missing into venv]
  H --> E[exec script]
  E --> I[click importable -> runs]
```

## Change

- `VenvPaths.BASE_RUNTIME_PACKAGES = ["click"]` — framework primitives every workflow script assumes importable.
- `DependencyChecker.merge_base_runtime()` — appends base packages not already declared (normalized-name compare; `click>=8` / `Click` are not duplicated).
- `check_and_install_deps()` — no longer short-circuits on empty `@requires`; always ensures base runtime in the resolved venv.

## Test

- 3 new unit tests (merge add / dedup; base install when `@requires` empty). Red before, green after.
- `uv run pytest tests/unit/test_pyenv.py -q` → 30 passed.
- End-to-end: bare global venv + `check_and_install_deps(["rich","textual"], "todos")` reports `Missing dependencies: rich, textual, click` and installs all three; `mcli run -g todos --help` works.

Version bump 8.0.59 → 8.0.60.

## Summary by Sourcery

Ensure isolated virtual environments for workflow scripts are seeded with required base runtime packages so they can run without a dev venv present.

New Features:
- Introduce configuration for base runtime packages (currently click) that must always be available in workflow virtual environments.

Bug Fixes:
- Prevent workflow scripts from failing with ModuleNotFoundError for click when running in a bare global virtual environment by always merging base runtime packages into dependency resolution.

Enhancements:
- Add DependencyChecker.merge_base_runtime to deduplicate and merge base runtime packages with script-declared requirements.
- Update dependency checking logic to handle empty @requires by still ensuring base runtime packages are installed.

Build:
- Bump project version from 8.0.59 to 8.0.60.

Tests:
- Add unit tests for merge_base_runtime behavior and for installing base runtime packages when no @requires are specified.