### PR TITLE
fix: ci preflight false-positive when act runs no job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install maturin
+        # Self-hosted runners persist site-packages across runs. A stale,
+        # non-editable `mcli` left in the interpreter's site-packages shadows
+        # the editable install below (Python imports the real package dir before
+        # the .pth-based editable entry), so tests run against old code and fail
+        # to import newly-added symbols. Force-remove any prior install first so
+        # the editable checkout is the only `mcli` on sys.path.
+        pip uninstall -y mcli mcli-framework 2>/dev/null || true
         pip install -e .[dev]
         # Self-hosted runner: pip falls back to --user installs, whose console
         # scripts (maturin, mcli, pytest) land in user-base/bin, not on PATH.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcli-framework"
-version = "8.0.60"
+version = "8.0.61"
 description = "Portable workflow framework - transform any script into a versioned, schedulable command. Store in ~/.mcli/workflows/, version with lockfile, run as daemon or cron job."
 readme = "README.md"
  requires-python = ">=3.10"

--- a/src/mcli/workflow/ci/act_runner.py
+++ b/src/mcli/workflow/ci/act_runner.py
@@ -28,13 +28,14 @@ _NO_STAGES_MARKERS = ("could not find any stages to run",)
 _RETRY_BACKOFF = (15, 45)
 _MAX_RETRIES = 2
 
-# Canonical CI entrypoint created by `mcli ci migrate`: ci.yml's `primary` job
-# runs on `workflow_dispatch` and calls the reusable `_ci-jobs.yml` with the
-# `runner_labels` input. The reusable workflow CANNOT run standalone (its
-# `runs-on: ${{ fromJSON(inputs.runner_labels) }}` has no value), so preflight
-# must drive it through this caller.
+# Canonical CI entrypoint created by `mcli ci migrate`: ci.yml runs on
+# `workflow_dispatch`. The job id is NOT fixed (`mcli ci migrate` keeps the
+# repo's original job name, e.g. `test`) — so preflight discovers the real job
+# id(s) from `act --list` rather than assuming a hardcoded name.
 _DISPATCH_WORKFLOW = Path(".github/workflows/ci.yml")
-_DISPATCH_JOB = "primary"
+
+# Header label of the job-id column in `act --list` table output.
+_JOB_ID_HEADER = "Job ID"
 
 
 class PreflightResult(Enum):
@@ -115,11 +116,51 @@ def default_container_arch() -> str | None:
     return None
 
 
-def dispatch_entrypoint() -> tuple[str, str] | None:
-    """The canonical (workflow, job) to drive via `workflow_dispatch`, or None."""
+def dispatch_workflow() -> str | None:
+    """The canonical workflow file to drive via `workflow_dispatch`, or None."""
     if _DISPATCH_WORKFLOW.exists():
-        return (str(_DISPATCH_WORKFLOW), _DISPATCH_JOB)
+        return str(_DISPATCH_WORKFLOW)
     return None
+
+
+def list_jobs(event: str, workflow: str | None = None) -> list[str]:
+    """Real job ids act would run for `event`, parsed from the `act --list` table.
+
+    `act --list` prints a table whose first row is a header containing a `Job ID`
+    column; each subsequent row is a runnable job. Returns job ids in table order
+    (deduplicated). Returns ``[]`` when act lists no jobs for the event (including
+    the "could not find any stages" no-op) or when act can't be invoked — never
+    raises, so callers can treat an empty result as "nothing to run".
+    """
+    cmd = ["act", event, "--list"]
+    if workflow is not None:
+        cmd += ["-W", workflow]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return []
+    return _parse_job_ids(proc.stdout or "")
+
+
+def _parse_job_ids(listing: str) -> list[str]:
+    """Extract the `Job ID` column from `act --list` table output."""
+    lines = [ln for ln in listing.splitlines() if ln.strip()]
+    if not lines:
+        return []
+    header = lines[0]
+    if _JOB_ID_HEADER not in header:
+        return []
+    # Columns are whitespace-separated; the job id is the second field in act's
+    # fixed-order table (Stage, Job ID, Job name, ...).
+    col = header.split().index(_JOB_ID_HEADER.split()[1]) - 1
+    job_ids: list[str] = []
+    for row in lines[1:]:
+        fields = row.split()
+        if len(fields) > col:
+            jid = fields[col]
+            if jid not in job_ids:
+                job_ids.append(jid)
+    return job_ids
 
 
 def build_act_command(
@@ -194,35 +235,61 @@ def run_act(
 
     Migrated repos are ``workflow_dispatch``-only, so the default
     ``pull_request`` event matches no jobs. Rather than hollow-pass, fall back
-    to the canonical ``ci.yml`` ``primary`` job on ``workflow_dispatch`` (which
-    drives the reusable ``_ci-jobs.yml``) and validate for real.
+    to the canonical ``ci.yml`` on ``workflow_dispatch``: discover its real job
+    id(s) via ``act --list`` (the job name is NOT fixed — ``mcli ci migrate``
+    keeps the repo's original name) and run each so the gate validates for real.
+
+    A green result means act actually executed ≥1 job and every job passed. If
+    ``act --list`` shows jobs but a run reports "could not find any stages"
+    (i.e. act ran nothing), that is a FAILURE, not a no-op — never a hollow pass.
     """
     arch = default_container_arch()
-    result, output = _run_with_retries(build_act_command(event, arch=arch), retries, backoff)
+    result, output = _run_with_retries(
+        build_act_command(event, arch=arch), retries, backoff
+    )
 
-    if result == PreflightResult.PASS and _has_no_stages(output):
-        entry = dispatch_entrypoint()
-        if entry is None:
-            sys.stdout.write(
-                "ℹ️  No act stages for this event and no ci.yml dispatch "
-                "entrypoint — nothing to validate; treating as pass.\n"
-            )
-            return PreflightResult.PASS
-        workflow, job = entry
+    if not (result == PreflightResult.PASS and _has_no_stages(output)):
+        return result
+
+    # No stages for the requested event — try the workflow_dispatch entrypoint.
+    workflow = dispatch_workflow()
+    if workflow is None:
         sys.stdout.write(
-            f"ℹ️  No '{event}' stages (workflow_dispatch-only); running "
-            f"{workflow} -j {job} via workflow_dispatch…\n"
+            "ℹ️  No act stages for this event and no ci.yml dispatch "
+            "entrypoint — nothing to validate; treating as pass.\n"
         )
+        return PreflightResult.PASS
+
+    jobs = list_jobs("workflow_dispatch", workflow)
+    if not jobs:
+        # The dispatch entrypoint genuinely has no jobs — a real no-op.
+        sys.stdout.write(
+            f"ℹ️  {workflow} has no workflow_dispatch jobs — nothing to "
+            "validate; treating as pass.\n"
+        )
+        return PreflightResult.PASS
+
+    targets = f"{workflow} {jobs}"
+    sys.stdout.write(
+        f"ℹ️  No '{event}' stages (workflow_dispatch-only); running "
+        f"{targets} via workflow_dispatch…\n"
+    )
+    for job in jobs:
         result, output = _run_with_retries(
-            build_act_command("workflow_dispatch", workflow=workflow, job=job, arch=arch),
+            build_act_command(
+                "workflow_dispatch", workflow=workflow, job=job, arch=arch
+            ),
             retries,
             backoff,
         )
-        # If even the dispatch entrypoint has no stages, it's a genuine no-op.
-        if result == PreflightResult.PASS and _has_no_stages(output):
-            return PreflightResult.PASS
+        if result == PreflightResult.UNREACHABLE:
+            return PreflightResult.UNREACHABLE
+        # We KNOW this job exists (it came from `act --list`), so "no stages"
+        # here means act ran nothing — a failure, not a no-op. Do not pass.
+        if result != PreflightResult.PASS or _has_no_stages(output):
+            return PreflightResult.FAIL
 
-    return result
+    return PreflightResult.PASS
 
 
 def preflight(repo_slug: str, event: str = "pull_request") -> PreflightResult:
@@ -235,7 +302,9 @@ def preflight(repo_slug: str, event: str = "pull_request") -> PreflightResult:
     same checks on the host toolchain, avoiding act's flaky container emulation.
     """
     if native_gate_available():
-        sys.stdout.write("▶ Native CI gate found — running `make ci-native` (no act)…\n")
+        sys.stdout.write(
+            "▶ Native CI gate found — running `make ci-native` (no act)…\n"
+        )
         return run_native()
     if not probe():
         return PreflightResult.UNREACHABLE

--- a/src/mcli/workflow/ci/act_runner.py
+++ b/src/mcli/workflow/ci/act_runner.py
@@ -244,9 +244,7 @@ def run_act(
     (i.e. act ran nothing), that is a FAILURE, not a no-op — never a hollow pass.
     """
     arch = default_container_arch()
-    result, output = _run_with_retries(
-        build_act_command(event, arch=arch), retries, backoff
-    )
+    result, output = _run_with_retries(build_act_command(event, arch=arch), retries, backoff)
 
     if not (result == PreflightResult.PASS and _has_no_stages(output)):
         return result
@@ -276,9 +274,7 @@ def run_act(
     )
     for job in jobs:
         result, output = _run_with_retries(
-            build_act_command(
-                "workflow_dispatch", workflow=workflow, job=job, arch=arch
-            ),
+            build_act_command("workflow_dispatch", workflow=workflow, job=job, arch=arch),
             retries,
             backoff,
         )
@@ -302,9 +298,7 @@ def preflight(repo_slug: str, event: str = "pull_request") -> PreflightResult:
     same checks on the host toolchain, avoiding act's flaky container emulation.
     """
     if native_gate_available():
-        sys.stdout.write(
-            "▶ Native CI gate found — running `make ci-native` (no act)…\n"
-        )
+        sys.stdout.write("▶ Native CI gate found — running `make ci-native` (no act)…\n")
         return run_native()
     if not probe():
         return PreflightResult.UNREACHABLE

--- a/tests/unit/workflow/test_ci_act_runner.py
+++ b/tests/unit/workflow/test_ci_act_runner.py
@@ -7,6 +7,7 @@ from mcli.workflow.ci.act_runner import (
     PreflightResult,
     build_act_command,
     default_container_arch,
+    list_jobs,
     native_gate_available,
     preflight,
     probe,
@@ -103,11 +104,51 @@ class TestRunAct:
             assert run_act("pull_request") == PreflightResult.PASS
 
 
+# `act --list` table output. The job id lives under the `Job ID` column; it is
+# NOT always `primary` — for a typical migrated repo it's whatever the original
+# job was called (here, `test`). Preflight must discover it, not assume it.
+_ACT_LIST_TEST_JOB = (
+    "Stage  Job ID  Job name  Workflow name  Workflow file  Events\n"
+    "0      test    test      ci             ci.yml         workflow_dispatch\n"
+)
+_ACT_LIST_TWO_JOBS = (
+    "Stage  Job ID  Job name  Workflow name  Workflow file  Events\n"
+    "0      lint    lint      ci             ci.yml         workflow_dispatch\n"
+    "0      test    test      ci             ci.yml         workflow_dispatch\n"
+)
+_ACT_LIST_EMPTY = "Stage  Job ID  Job name  Workflow name  Workflow file  Events\n"
+
+
+class TestListJobs:
+    """`list_jobs` parses real job ids out of the `act --list` table so the
+    dispatch fallback never has to guess (`primary` was a wrong guess: defect 1)."""
+
+    def test_parses_single_job_id(self):
+        with patch("subprocess.run", return_value=_cp(0, stdout=_ACT_LIST_TEST_JOB)):
+            assert list_jobs("workflow_dispatch", ".github/workflows/ci.yml") == ["test"]
+
+    def test_parses_multiple_job_ids(self):
+        with patch("subprocess.run", return_value=_cp(0, stdout=_ACT_LIST_TWO_JOBS)):
+            assert list_jobs("workflow_dispatch", ".github/workflows/ci.yml") == [
+                "lint",
+                "test",
+            ]
+
+    def test_empty_table_is_no_jobs(self):
+        with patch("subprocess.run", return_value=_cp(0, stdout=_ACT_LIST_EMPTY)):
+            assert list_jobs("workflow_dispatch", ".github/workflows/ci.yml") == []
+
+    def test_no_stages_output_is_no_jobs(self):
+        out = "Error: Could not find any stages to run."
+        with patch("subprocess.run", return_value=_cp(1, stdout=out)):
+            assert list_jobs("workflow_dispatch", ".github/workflows/ci.yml") == []
+
+
 class TestDispatchFallback:
     """workflow_dispatch-only repos (migrated by `mcli ci migrate`) have no
-    pull_request stages. Rather than hollow-pass, preflight must run the
-    canonical ci.yml `primary` job via workflow_dispatch so it actually
-    validates the gates."""
+    pull_request stages. Rather than hollow-pass, preflight must discover the
+    real ci.yml job id(s) via `act --list` and run them via workflow_dispatch so
+    it actually validates the gates."""
 
     _NO_STAGES = "Error: Could not find any stages to run."
 
@@ -117,29 +158,72 @@ class TestDispatchFallback:
         (wf / "ci.yml").write_text("name: ci\non:\n  workflow_dispatch:\n")
         monkeypatch.chdir(tmp_path)
 
+    def test_dispatch_uses_discovered_job_not_primary(self, tmp_path, monkeypatch):
+        """Defect 1: the dispatch run must target the real job id from
+        `act --list` (`test`), never the hardcoded `primary`."""
+        self._with_ci_yml(tmp_path, monkeypatch)
+        with (
+            patch("mcli.workflow.ci.act_runner.list_jobs", return_value=["test"]) as list_m,
+            # 1st run: pull_request -> no stages; 2nd run: dispatch -> exit 0.
+            patch("subprocess.run", side_effect=[_cp(1, stdout=self._NO_STAGES), _cp(0)]) as run_m,
+        ):
+            assert run_act("pull_request") == PreflightResult.PASS
+        list_m.assert_called_once()
+        dispatch_cmd = run_m.call_args_list[1].args[0]
+        assert "workflow_dispatch" in dispatch_cmd
+        assert "-j" in dispatch_cmd and "test" in dispatch_cmd
+        assert "primary" not in dispatch_cmd
+
     def test_no_stages_then_dispatch_passes(self, tmp_path, monkeypatch):
         self._with_ci_yml(tmp_path, monkeypatch)
-        # 1st call (pull_request) -> no stages; 2nd call (dispatch) -> exit 0.
-        seq = [_cp(1, stdout=self._NO_STAGES), _cp(0)]
-        with patch("subprocess.run", side_effect=seq) as m:
+        with (
+            patch("mcli.workflow.ci.act_runner.list_jobs", return_value=["test"]),
+            patch("subprocess.run", side_effect=[_cp(1, stdout=self._NO_STAGES), _cp(0)]),
+        ):
             assert run_act("pull_request") == PreflightResult.PASS
-        assert m.call_count == 2
-        # 2nd invocation targets ci.yml primary on workflow_dispatch.
-        second = m.call_args_list[1].args[0]
-        assert "workflow_dispatch" in second
-        assert "-j" in second and "primary" in second
 
     def test_no_stages_then_dispatch_fails(self, tmp_path, monkeypatch):
         self._with_ci_yml(tmp_path, monkeypatch)
-        seq = [_cp(1, stdout=self._NO_STAGES), _cp(1, stdout="3 tests failed")]
-        with patch("subprocess.run", side_effect=seq):
+        with (
+            patch("mcli.workflow.ci.act_runner.list_jobs", return_value=["test"]),
+            patch(
+                "subprocess.run",
+                side_effect=[
+                    _cp(1, stdout=self._NO_STAGES),
+                    _cp(1, stdout="3 tests failed"),
+                ],
+            ),
+        ):
             assert run_act("pull_request") == PreflightResult.FAIL
 
-    def test_dispatch_also_no_stages_is_pass(self, tmp_path, monkeypatch):
+    def test_dispatch_no_stages_despite_listed_job_is_fail(self, tmp_path, monkeypatch):
+        """Defect 2: if `act --list` shows a job but the dispatch run still says
+        'could not find any stages' (e.g. wrong `-j` / act ran nothing), that is a
+        FAILURE, not a hollow pass. Green must mean a job actually executed."""
         self._with_ci_yml(tmp_path, monkeypatch)
-        seq = [_cp(1, stdout=self._NO_STAGES), _cp(1, stdout=self._NO_STAGES)]
-        with patch("subprocess.run", side_effect=seq):
+        with (
+            patch("mcli.workflow.ci.act_runner.list_jobs", return_value=["test"]),
+            patch(
+                "subprocess.run",
+                side_effect=[
+                    _cp(1, stdout=self._NO_STAGES),
+                    _cp(1, stdout=self._NO_STAGES),
+                ],
+            ),
+        ):
+            assert run_act("pull_request") == PreflightResult.FAIL
+
+    def test_genuinely_no_jobs_is_pass(self, tmp_path, monkeypatch):
+        """If `act --list` shows the dispatch entrypoint has NO jobs at all, it's a
+        real no-op and the gate passes without claiming a job ran."""
+        self._with_ci_yml(tmp_path, monkeypatch)
+        with (
+            patch("mcli.workflow.ci.act_runner.list_jobs", return_value=[]),
+            patch("subprocess.run", side_effect=[_cp(1, stdout=self._NO_STAGES)]) as run_m,
+        ):
             assert run_act("pull_request") == PreflightResult.PASS
+        # only the initial pull_request probe ran; no dispatch run attempted.
+        assert run_m.call_count == 1
 
 
 class TestRunActDockerRateLimit:
@@ -202,7 +286,10 @@ class TestPreflight:
         # When a native `make ci-native` exists, run it and SKIP act entirely.
         with (
             patch("mcli.workflow.ci.act_runner.native_gate_available", return_value=True),
-            patch("mcli.workflow.ci.act_runner.run_native", return_value=PreflightResult.PASS),
+            patch(
+                "mcli.workflow.ci.act_runner.run_native",
+                return_value=PreflightResult.PASS,
+            ),
             patch("mcli.workflow.ci.act_runner.probe") as probe_m,
             patch("mcli.workflow.ci.act_runner.run_act") as act_m,
         ):
@@ -213,7 +300,10 @@ class TestPreflight:
     def test_native_fail_blocks(self):
         with (
             patch("mcli.workflow.ci.act_runner.native_gate_available", return_value=True),
-            patch("mcli.workflow.ci.act_runner.run_native", return_value=PreflightResult.FAIL),
+            patch(
+                "mcli.workflow.ci.act_runner.run_native",
+                return_value=PreflightResult.FAIL,
+            ),
         ):
             assert preflight("o/r") == PreflightResult.FAIL
 


### PR DESCRIPTION
## Summary

`mcli ci preflight` reported `✅ act passed` even when `act` ran **nothing**. On a repo whose `ci.yml` is `workflow_dispatch`-only with job id `test`, the dispatch fallback invoked `act ... -j primary` — but `primary` isn't a real job, so `act` errored with "Could not find any stages to run" and exited non-zero. Preflight then mis-classified that no-op as a pass.

### Two defects fixed

1. **Hardcoded job id.** The fallback assumed the dispatch job was named `primary`. `mcli ci migrate` keeps the repo's original job name (e.g. `test`), so `-j primary` matches nothing. Now the real job id(s) are discovered from `act --list` (new `list_jobs`) and each is run.
2. **Exit code ignored → false positive.** A "no stages" result on the dispatch run was treated as a no-op pass. Now, if `act --list` shows a job exists but the run reports "no stages" or exits non-zero, that is a **FAILURE**. A genuine no-op (no jobs listed at all) still passes. Green means act actually executed ≥1 job and every job passed.

## Before / After

**Before**
```mermaid
flowchart TD
    A[act pull_request] -->|no stages| B[run act -j primary]
    B -->|primary not found: no stages, exit 1| C{result == PASS and no_stages?}
    C -->|yes| D["✅ act passed (FALSE: nothing ran)"]
```

**After**
```mermaid
flowchart TD
    A[act pull_request] -->|no stages| B[list_jobs via act --list]
    B -->|no jobs at all| P["✅ pass (genuine no-op)"]
    B -->|jobs = test, ...| R[run each job via workflow_dispatch]
    R -->|job runs, exit 0| OK["✅ act passed (a job really ran)"]
    R -->|no stages / non-zero| F["❌ act failed"]
```

## Tests (TDD, mocked act — no Docker/act needed)

- `TestListJobs::test_parses_single_job_id` / `test_parses_multiple_job_ids` / `test_empty_table_is_no_jobs` / `test_no_stages_output_is_no_jobs`
- `TestDispatchFallback::test_dispatch_uses_discovered_job_not_primary` (defect 1)
- `TestDispatchFallback::test_dispatch_no_stages_despite_listed_job_is_fail` (defect 2)
- `TestDispatchFallback::test_genuinely_no_jobs_is_pass`, `test_no_stages_then_dispatch_passes`, `test_no_stages_then_dispatch_fails`

## Validation

`uv run pytest tests/unit/workflow/test_ci_act_runner.py tests/unit/workflow/test_ci_cli.py` → 52 passed. Full `tests/unit/workflow/` → 102 passed. `act`/Docker not available in this environment, so the act-first remote gate could not be run locally; validated by the affected unit suites instead.

Version bumped 8.0.60 → 8.0.61.

## Summary by Sourcery

Tighten the `mcli ci preflight` act-based gate so it only reports success when act actually executes at least one CI job and all jobs pass, including for workflow_dispatch-only repos.

Bug Fixes:
- Fix dispatch fallback to target real workflow_dispatch job IDs discovered from `act --list` instead of assuming a hardcoded `primary` job.
- Treat cases where act lists jobs but then runs no stages or exits non-zero as failures rather than hollow passes, eliminating false-positive preflight results.

Build:
- Bump framework version from 8.0.60 to 8.0.61.

Tests:
- Expand unit coverage around act job discovery and dispatch fallback behavior, including parsing `act --list` output, multiple jobs, genuine no-op cases, and failure scenarios.

---

## CI green-up (follow-up commits)

Two hosted checks were red on this branch; both are now addressed:

1. **Lint and Format Check** — a prior `--no-verify` commit skipped Black, leaving
   `act_runner.py` unformatted (`black --check` failed). Reapplied Black.
2. **Test Python Package (3.12)** — the self-hosted runner imported a *stale,
   non-editable* `mcli` from its persistent site-packages, which predated the new
   `list_jobs` symbol, so test collection failed with
   `ImportError: cannot import name 'list_jobs'`. The editable checkout was being
   shadowed. Fixed in `ci.yml` by uninstalling any prior `mcli`/`mcli-framework`
   before `pip install -e .[dev]`, so the checkout is the only copy on `sys.path`.

```text
Before (test-python install)            After
----------------------------            -----
pip install -e .[dev]                   pip uninstall -y mcli mcli-framework || true
  └─ shadowed by stale site-packages    pip install -e .[dev]
     mcli  →  ImportError(list_jobs)       └─ editable checkout is the only mcli
